### PR TITLE
Create conda-forge meta.yaml for OpenSpec

### DIFF
--- a/recipes/openspec/meta.yaml
+++ b/recipes/openspec/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "openspec" %}
+{% set npm_name = "@fission-ai/openspec" %}
+{% set npm_scope = "fission-ai" %}
+{% set version = "0.16.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://registry.npmjs.org/{{ npm_name }}/-/{{ name }}-{{ version }}.tgz
+  sha256: d58717a3cb0d59a9ab09095ddf73c4fddc99affbf3d1d6515a9f1d9038e7cd60
+
+build:
+  number: 0
+  script:
+    - export npm_config_prefix="${PREFIX}"  # [unix]
+    - export NPM_CONFIG_USERCONFIG=/tmp/nonexistentrc  # [unix]
+    - npm pack  # [unix]
+    - npm install -g {{ npm_scope }}-${PKG_NAME}-${PKG_VERSION}.tgz  # [unix]
+    - npm config set prefix "%PREFIX%"  # [win]
+    - npm pack  # [win]
+    - npm install --userconfig nonexistentrc -g {{ npm_scope }}-%PKG_NAME%-%PKG_VERSION%.tgz  # [win]
+
+requirements:
+  host:
+    - nodejs >=20.19.0
+  run:
+    - nodejs >=20.19.0
+
+test:
+  commands:
+    - {{ name }} --help
+    - test -f $PREFIX/bin/{{ name }}  # [unix]
+    - if not exist %PREFIX%\bin\{{ name }} exit 1  # [win]
+
+about:
+  home: https://github.com/Fission-AI/OpenSpec
+  summary: AI-native system for spec-driven development
+  description: |
+    OpenSpec is a specification-driven development framework that aligns humans
+    and AI coding assistants through structured specs before implementation.
+    It enables spec-driven development for AI coding assistants with no API keys required.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/openspec/recipe.yaml
+++ b/recipes/openspec/recipe.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: openspec
+  npm_name: "@fission-ai/openspec"
+  npm_scope: fission-ai
+  version: "0.16.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://registry.npmjs.org/${{ npm_name }}/-/${{ name }}-${{ version }}.tgz
+  sha256: d58717a3cb0d59a9ab09095ddf73c4fddc99affbf3d1d6515a9f1d9038e7cd60
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - export npm_config_prefix="${PREFIX}"
+        - export NPM_CONFIG_USERCONFIG=/tmp/nonexistentrc
+        - npm pack
+        - npm install -g fission-ai-${PKG_NAME}-${PKG_VERSION}.tgz
+    - if: win
+      then:
+        - npm config set prefix "%PREFIX%"
+        - npm pack
+        - npm install --userconfig nonexistentrc -g fission-ai-%PKG_NAME%-%PKG_VERSION%.tgz
+
+requirements:
+  host:
+    - nodejs >=20.19.0
+  run:
+    - nodejs >=20.19.0
+
+tests:
+  - script:
+      - ${{ name }} --help
+  - script:
+      - if: unix
+        then: test -f $PREFIX/bin/${{ name }}
+      - if: win
+        then: if not exist %PREFIX%\bin\${{ name }} exit 1
+
+about:
+  summary: AI-native system for spec-driven development
+  description: |
+    OpenSpec is a specification-driven development framework that aligns humans
+    and AI coding assistants through structured specs before implementation.
+    It enables spec-driven development for AI coding assistants with no API keys required.
+  homepage: https://github.com/Fission-AI/OpenSpec
+  repository: https://github.com/Fission-AI/OpenSpec
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - rxm7706


### PR DESCRIPTION
…script template

- Add modern recipe.yaml for @fission-ai/openspec (v0.16.0)
- Recipe uses inline scripts for reliable rattler-build compatibility
- Fix skill Template 7: change bld.bat to build.bat for rattler-build
- Add recommended inline script approach for simple Node.js packages
- Bump skill version to 2.3.0

    ge: openspec v0.16.0
    Source: npm registry (@fission-ai/openspec)
    License: MIT
    Dependencies: nodejs >=20.19.0
    Tests: CLI help command + binary existence check

Build & Test Results

    Linting: conda-smithy recipe-lint - Passed
    Build: rattler-build build - Successful (827KB package)
    Tests: All tests passed
        openspec --help - Works correctly
        Binary exists at $PREFIX/bin/openspec

Skill Updates (v2.2.0 → v2.3.0)

During the process, I discovered issues with the skill's Node.js template:

    Fixed bld.bat → build.bat: rattler-build uses build.bat (not bld.bat) for Windows builds. The linter flagged this.

    Added inline script recommendation: External script files weren't being copied to the work directory by rattler-build. Inline scripts in recipe.yaml are more reliable.

    Updated Template 7:
        Added prominent warning about build.bat vs bld.bat
        Added recommended inline script example
        Renamed external script example from bld.bat to build.bat
