### PR TITLE
docs(specs): re-ground langflow-conda-forge spec with ultraplan findings

### DIFF
--- a/docs/specs/langflow-conda-forge.md
+++ b/docs/specs/langflow-conda-forge.md
@@ -1,8 +1,8 @@
 ---
 status: ready
 implemented_by: bmad-quick-dev
-shipped_ref: "full local closure built GREEN; conda-forge submission + skew-fix unimplemented"
-scope: full-closure   # core hard-dep closure + ALL optional run_constraints integrations (incl. ~20 not-yet-authored) + ALL 3 external cf skews. Nothing deferred except the 3 named caveats.
+shipped_ref: "full local closure built GREEN (incl. ALL Set-C integrations now authored); conda-forge submission + skew-fix unimplemented; ultraplan-grounded + Q1–Q5 resolved 2026-06-23"
+scope: full-closure   # core hard-dep closure + ALL optional run_constraints integrations (Set C now ALL authored locally) + ALL 3 external cf skews. Nothing deferred except the 3 named caveats (handled per § Caveats: elasticsearch gated on cf PR #122; apify-client attempt-or-drop; ragstack kept local-only).
 spec_updated: 2026-06-23
 ---
 # Tech Spec: langflow-suite on conda-forge (submission + external-skew remediation)
@@ -53,7 +53,7 @@ spec_updated: 2026-06-23
 
 | Field | Value |
 | ----- | ----- |
-| Status | **Local closure built GREEN; conda-forge submission not started; langflow-suite test-blocked on one external cf skew.** All ~46 prerequisite recipes are authored and built into the local channel; `recipes/langflow-suite/` builds clean for all 3 outputs (`--test skip` GREEN, 2026-06-23). The langflow-suite test-env solve is blocked by the **langchain-text-splitters** skew (§ External Skews). |
+| Status | **Local closure built GREEN; conda-forge submission not started; langflow-suite test-blocked on one external cf skew.** All ~46 core prerequisite recipes AND **all ~18 Set-C optional integrations are now authored + built** into the local channel (ultraplan re-grounding, 2026-06-23 — Set C is no longer "to author"; `spider-client`, `assemblyai`, `impit` are all present + `build=success`). `recipes/langflow-suite/` builds clean for all 3 outputs (`--test skip` GREEN, 2026-06-23). The langflow-suite test-env solve is blocked by the **langchain-text-splitters** skew (§ External Skews). **Residual work is now skew-fix → re-verify GREEN → leaves-first submission** (authoring is effectively complete). Only `firecrawl-py` lacks a build record and needs a verification build. |
 | Owner | rxm7706 |
 | Track | BMAD Quick Flow (tech-spec only) |
 | Upstream | `langflow-ai/langflow` v1.10.0 (MIT). Monorepo split into `lfx` (executor core, `src/lfx`), `langflow-base` (`src/backend/base`, ships the `langflow` import), `langflow` (umbrella, `.`), and the `lfx-*` extension plugins. |
@@ -73,13 +73,19 @@ spec_updated: 2026-06-23
 - **The 4 `lfx-*` extension plugins are SEPARATE feedstocks** (`lfx-arxiv`, `lfx-docling`,
   `lfx-duckduckgo`, `lfx-ibm`). The `langflow` umbrella **hard-deps** all four
   (upstream `langflow` `[project.dependencies]` = `langflow-base[complete]` + the 4 `lfx-*`).
-- **⚠ Cross-feedstock cycle → split `lfx` out (Open Question Q1).** `langflow` (a suite output)
-  hard-deps the 4 `lfx-*`; each `lfx-*` deps `lfx` (also a suite output). A single suite feedstock
-  cannot satisfy "lfx on cf → lfx-* on cf → langflow tests" in one shot. **Recommended submission
-  shape: split `lfx` into its own feedstock submitted first**, then `lfx-*`, then a
-  `langflow-base`+`langflow` recipe (2-output suite, or two recipes). The current single
-  3-output recipe is fine for *local* build verification but not for the staged-recipes
-  dependency order.
+- **⚠ Cross-feedstock cycle → KEEP the single 3-output recipe (Q1 RESOLVED — do NOT split).**
+  `langflow` (a suite output) hard-deps the 4 `lfx-*`; each `lfx-*` deps `lfx` (also a suite
+  output). **Decision (rxm7706, 2026-06-23):** keep the **single 3-output `langflow-suite`
+  recipe** (lfx + langflow-base + langflow) so the three versions stay locked together — better
+  long-term (one feedstock; autotick bumps lfx/langflow-base/langflow in lockstep). This
+  overrides the earlier "split lfx out" recommendation.
+  The residual is a **bootstrap cycle at the *initial* staged-recipes gate**: `langflow`'s
+  test-env solve needs the 4 separate `lfx-*` feedstocks, which need `lfx` (a suite output not
+  yet on cf). **Mitigation = sequencing + a temporary test relaxation, NOT splitting:** submit
+  the 3-output suite first so `lfx` publishes → submit the 4 `lfx-*` (now `lfx` is on cf) →
+  build-number-bump follow-up to tighten/enable `langflow`'s full test (or relax just the
+  `langflow` output's lfx-* import test on the first submission, then re-enable). Once all are
+  on cf the single-feedstock shape is exactly what's wanted.
 - **Dependency lists come from upstream pyproject, not the hand-authored recipe lists.** Earlier
   the recipe's output `run:` lists diverged from upstream (e.g. fabricated `atlaspy`/`dynamicconf`;
   truncated `lfx` deps). For each output, flatten the real upstream `[project.dependencies]`
@@ -153,32 +159,44 @@ grandalf, mcp, cryptography, …).
 | **langflow-base** *(suite)* | blocked-pending-prereq | noarch | MIT | lfx, jsonquerylang, spider-client, assemblyai, firecrawl-py, langchain stack |
 | **langflow** *(suite)* | blocked-pending-prereq | noarch | MIT | langflow-base[complete], lfx-arxiv, lfx-docling, lfx-duckduckgo, lfx-ibm |
 
-> **Re-verify before each wave:** the `langflow-base` and `langflow` hard-dep closures include
-> a few more net-new packages not yet scanned/authored (notably **`spider-client`** and
-> **`assemblyai`**, both langflow-base BASE deps, missing from cf). BMAD must flatten each
-> output's real upstream `[project.dependencies]` (umbrella also `langflow-base[complete]`, G25),
-> run `check_dependencies` on the flattened recipe (G29), and author any still-missing leaf before
-> that wave.
+> **Re-verify before each wave:** **`spider-client`** and **`assemblyai`** (both langflow-base
+> BASE deps) are now **authored + `build=success` locally** (ultraplan scan 2026-06-23) — no
+> longer "to author". BMAD must still flatten each output's real upstream `[project.dependencies]`
+> (umbrella also `langflow-base[complete]`, G25), run `check_dependencies` on the **flattened
+> single-output** recipe (G29 — multi-output checkers are top-level-only), and author any
+> still-missing leaf before that wave. Only `firecrawl-py` currently lacks a `cfe-local-build-*`
+> record — build + verify it in Wave A.
 
 ### C. Optional integrations (`run_constraints`) — full-closure scope
 
 Soft constraints; they do not block langflow-suite install, but the full suite experience wants
-them on cf. Already-built (submit in Wave C): the 5 `langchain-*` in table B above marked as
-already authored. **Not yet authored — author + submit:** `ag2`, `assemblyai`, `astrapy`,
-`cassio`, `cleanlab-tlm`, `composio-langchain`, `langchain-cohere`,
-`langchain-google-calendar-tools`, `langchain-nvidia-ai-endpoints`, `langchain-pinecone`,
-`langchain-unstructured`, `langchain-weaviate`, `mem0ai`, `metal-sdk`, `needle-python`,
-`openlayer`, `opik`, `scrapegraph-py`, `spider-client`, `upstash-vector`.
+them on cf. **CORRECTION (ultraplan scan 2026-06-23): the entire Set-C list below is now AUTHORED
++ present locally** — the spec's earlier "not yet authored" claim is stale. Authoring is
+effectively complete; Wave C is now **re-verify each leaf → submit leaves-first**, not "author +
+submit". Set C (all present): `ag2`, `astrapy`, `cassio`, `cleanlab-tlm`, `composio-langchain`,
+`langchain-cohere`, `langchain-google-calendar-tools`, `langchain-nvidia-ai-endpoints`,
+`langchain-pinecone`, `langchain-unstructured`, `langchain-weaviate`, `mem0ai`, `metal-sdk`,
+`needle-python`, `openlayer`, `opik`, `scrapegraph-py`, `upstash-vector` — plus the 5 already-built
+`langchain-*` in table B and the now-relocated-to-B `spider-client` + `assemblyai` (langflow-base
+hard deps, not optional). Submit each leaf (SDK) before its `langchain-*` wrapper; re-run
+`check_dependencies` per leaf since each carries its own recursive sub-closure. Skews 2 + 3 gate
+this wave (not the core suite).
 
-### Caveats (special handling — do NOT submit naively)
+### Caveats (special handling — do NOT submit naively) — RESOLVED 2026-06-23
 
-- **`ragstack-ai-knowledge-store` — BUSL-1.1, NOT conda-forge-eligible** (non-OSI). Drop from the
-  submission set; confirm `opendsstar` resolves without it (Q2).
+- **`ragstack-ai-knowledge-store` — BUSL-1.1, NOT conda-forge-eligible** (non-OSI). **Q2 RESOLVED:**
+  **keep the recipe locally** (it's present) **but commented-out / clearly marked
+  `BUSL-1.1 / non-OSI — out of scope for conda-forge`; NEVER submit.** Confirm `opendsstar`
+  resolves without it (is it a hard or optional opendsstar dep? — verify in Wave A).
 - **`langchain-elasticsearch` — blocked on a cf gap:** requires `elasticsearch >=8.19,<9` which
-  does not exist on conda-forge (feedstock jumps 8.18.0 → 9.0.0). File an `elasticsearch-feedstock`
-  version-bump request, or drop (Q5).
-- **`apify-client` — blocked on `impit` py311+** (G38: `impit` is compiled, only py310 in the
-  local channel). Build `impit` for the py311+ matrix, or drop `apify-client` (Q4).
+  did not exist on conda-forge (feedstock jumps 8.18.0 → 9.0.0). **Q5 RESOLVED: INCLUDE, gated on
+  the live `elasticsearch-feedstock` bump — `conda-forge/elasticsearch-feedstock` PR #122
+  (https://github.com/conda-forge/elasticsearch-feedstock/pull/122) is UP.** Submit
+  `langchain-elasticsearch` once #122 merges and `elasticsearch >=8.19` is on cf.
+- **`apify-client` — was blocked on `impit` py311+** (G38). **Q4 RESOLVED: ATTEMPT — `impit` is now
+  present + `build=success` locally.** Verify `impit` covers the consumer's py3.11 matrix (G38),
+  then include `apify-client`. **Flag as at-risk: if it can't be unblocked cleanly, DROP it**
+  (optional integration; dropping is acceptable).
 
 ---
 
@@ -202,6 +220,11 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
   `langchain-text-splitters` run-dep so it admits `>=1.1.0` (match upstream + `langchain-classic`),
   rerender, merge. **Verify first** against the exact cf-pinned 1.2.x upstream metadata
   (`pypi.org/pypi/langchain/<ver>/json`).
+- **Approach RESOLVED (rxm7706, 2026-06-23): local rebuild FIRST, then the upstream PR.** Rebuild
+  `langchain` locally with the loosened text-splitters pin to confirm `lfx` + the 3-output
+  `langflow-suite` go **test-GREEN on the py3.11 leg** fast (no outward action / no waiting on
+  external review). THEN file the ~1-line `conda-forge/langchain-feedstock` PR as the durable fix.
+  The local rebuild is the iteration loop; the upstream PR is what actually unblocks cf submission.
 - **Note:** `langchain 1.2.x` is NOT py3.13-only — it has `pymin310` builds (`python >=3.10,<3.13`)
   covering py3.11; Python is not the blocker, the text-splitters pin is.
 - **Diagnosis test:** solve `langchain` + `langchain-classic` + `langchain-text-splitters` in
@@ -233,10 +256,13 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 
 ### Wave A — clear the external skews (gate to langflow-suite test-GREEN)
 
-- **A1 — langchain-text-splitters (Skew 1).** File + land the `langchain-feedstock` text-splitters
-  pin fix. This is the **only** skew blocking the core suite. After it merges (or via a local
-  langchain rebuild for fast iteration), re-attempt `langflow-suite` → require all 3 outputs
-  build + test GREEN (py3.11 leg). Flip cfe-status to `pending-submission-to-conda-forge`.
+- **A1 — langchain-text-splitters (Skew 1).** **Local rebuild FIRST** (resolved approach): rebuild
+  `langchain` locally with the loosened text-splitters pin → rebuild `lfx` → re-attempt the
+  3-output `langflow-suite` → require all 3 outputs **build + test GREEN (py3.11 leg)**. This is the
+  **only** skew blocking the core suite. THEN file + land the `conda-forge/langchain-feedstock`
+  ~1-line pin fix (the durable unblock for cf submission). Also in A1: **build + verify
+  `firecrawl-py`** (only closure recipe lacking a build record), and confirm `opendsstar` resolves
+  without `ragstack-ai-knowledge-store`. Flip affected cfe-status to `pending-submission-to-conda-forge`.
 - **A2 — litellm/fastapi (Skew 2)** and **A3 — otel cluster (Skew 3).** Needed only for the
   optional-integration closure (Wave C). Drive in parallel; not a gate for Wave B.
 
@@ -252,19 +278,28 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 4. **B4:** ibm-watsonx-ai (→ibm-cos-sdk); also build 1.3.37 for the py3.10 leg (G40).
 5. **B5:** langchain-ibm (→ibm-watsonx-ai), agent-lifecycle-toolkit (→ibm-watsonx-ai, smolagents,
    llm-sandbox), opendsstar (→pymilvus-model, milvus-lite, langchain-milvus, smolagents, ragworkbench).
-6. **B6:** **lfx** (own feedstock — Q1) → langflow-sdk, opendsstar, jsonquerylang + cf langchain stack.
-7. **B7:** lfx-arxiv, lfx-docling, lfx-duckduckgo (→ddgs), lfx-ibm (→langchain-ibm, ibm-watsonx-ai)
-   — all → lfx.
-8. **B8:** langflow-base (→lfx, spider-client, assemblyai, firecrawl-py) + langflow
-   (→langflow-base[complete], the 4 lfx-*). Ship as a 2-output suite or two recipes (Q1).
+6. **B6 (single 3-output suite — Q1 RESOLVED, NOT split):** submit `recipes/langflow-suite/`
+   producing **lfx + langflow-base + langflow** in one PR (→ langflow-sdk, opendsstar,
+   jsonquerylang, spider-client, assemblyai, firecrawl-py + cf langchain stack). Because the 4
+   `lfx-*` feedstocks aren't on cf yet, **temporarily relax the `langflow` output's lfx-* import
+   test** for this first submission (the bootstrap cycle — see § Packaging shape). This publishes
+   `lfx`.
+7. **B7:** submit the 4 `lfx-*` feedstocks (now that `lfx` is on cf): lfx-arxiv, lfx-docling,
+   lfx-duckduckgo (→ddgs), lfx-ibm (→langchain-ibm, ibm-watsonx-ai) — all → lfx.
+8. **B8 (follow-up):** build-number-bump PR on `langflow-suite` to **re-enable / tighten the
+   `langflow` output's full lfx-* test** now that all 4 `lfx-*` are on cf. Suite versions stay
+   locked together from here on (autotick maintains lfx/langflow-base/langflow in lockstep).
 
 ### Wave C — submit optional integrations (full-closure scope)
 
 - Submit the already-built `langchain-*` (astradb, graph-retriever, google-vertexai, sambanova,
   google-community) once their SDK leaves are on cf.
-- Author + submit the not-yet-authored set (§ Submission set C), leaves-first (SDK leaf before its
-  `langchain-*` wrapper). Resolve the 3 caveats (ragstack drop; langchain-elasticsearch /
-  elasticsearch>=8.19; apify-client / impit py311).
+- **Re-verify + submit** the rest of Set C (§ Submission set C) — **all now authored** — leaves-first
+  (SDK leaf before its `langchain-*` wrapper); re-run `check_dependencies` per leaf.
+- Caveats (resolved): **ragstack** kept local-only, commented-out (BUSL-1.1/non-OSI — never submit);
+  **langchain-elasticsearch** submitted once `elasticsearch-feedstock` PR #122 merges
+  (elasticsearch >=8.19 on cf); **apify-client** attempted (impit built — G38 py311 verify), dropped
+  if it can't be unblocked.
 
 ### Wave D — closeout
 
@@ -293,20 +328,23 @@ langflow-base → langflow.
 
 ---
 
-## Open Questions
+## Open Questions — ALL RESOLVED 2026-06-23 (rxm7706, via ultraplan)
 
-- **Q1 — suite shape (recommend split lfx).** Submit `lfx` as its own feedstock first (breaks the
-  `langflow → lfx-* → lfx` cycle), keep `langflow-base`+`langflow` as a 2-output suite — vs. forcing
-  the single 3-output recipe through staged-recipes (cannot satisfy the cycle in one PR). Spec
-  recommends the split.
-- **Q2 — ragstack-ai-knowledge-store BUSL-1.1.** Non-OSI → drop from the cf set; confirm `opendsstar`
-  resolves without it (is it a hard or optional opendsstar dep?).
-- **Q3 — python_min 3.11.** Confirm reviewers accept langflow declaring `python_min 3.11` (the honest
-  floor per G41; upstream `requires-python>=3.10` is broken).
-- **Q4 — apify-client / impit.** Build `impit` for the py311+ matrix (G38), or drop `apify-client`
-  (optional integration).
-- **Q5 — langchain-elasticsearch / elasticsearch ≥8.19.** File an `elasticsearch-feedstock`
-  version-bump request, or drop the integration.
+- **Q1 — suite shape. RESOLVED: KEEP the single 3-output recipe (do NOT split lfx).** lfx +
+  langflow-base + langflow ship from one `langflow-suite` feedstock so the three versions stay
+  locked together (better long-term; autotick bumps them in lockstep). The `langflow → lfx-* → lfx`
+  bootstrap cycle is handled at the *initial* staged-recipes gate by **sequencing + a temporary
+  relaxation of the `langflow` output's lfx-* test** (Wave B6 → B7 → B8 follow-up), not by splitting.
+- **Q2 — ragstack-ai-knowledge-store BUSL-1.1. RESOLVED: keep the recipe LOCAL-ONLY, commented-out,
+  marked non-OSI/out-of-scope; NEVER submit.** Confirm `opendsstar` resolves without it (Wave A).
+- **Q3 — python_min 3.11. RESOLVED: declare `python_min 3.11` across the suite** (honest floor per
+  G41 — jsonquerylang hard-imports `typing.NotRequired`/PEP 655; upstream `requires-python>=3.10` is
+  broken). Reviewer pushback is answerable.
+- **Q4 — apify-client / impit. RESOLVED: ATTEMPT** (impit now present + `build=success`; verify py3.11
+  matrix per G38), **flag at-risk; DROP if it can't be unblocked cleanly.**
+- **Q5 — langchain-elasticsearch / elasticsearch ≥8.19. RESOLVED: INCLUDE, gated on
+  `conda-forge/elasticsearch-feedstock` PR #122**
+  (https://github.com/conda-forge/elasticsearch-feedstock/pull/122, UP). Submit once #122 merges.
 
 ---
 
@@ -319,3 +357,15 @@ Build-Failure-Protocol note (shipped CFE v8.35.0). The 2026-06-23 session fixed 
 upstream's ~43 deps with G24 caps + G25 `httpx[http2]` flatten), confirmed **all 3 outputs build
 GREEN** (`--test skip`), and pinned the residual blocker to **Skew 1 (langchain-text-splitters)** —
 a stale `langchain-feedstock` pin, the precise fix for which is Wave A1.
+
+The **2026-06-23 ultraplan re-grounding** session (this update) read the spec in full under the
+`conda-forge-expert` skill, **re-scanned `recipes/` against the closure**, and found the repo
+materially ahead of the spec's prose: **all ~46 core recipes AND all ~18 Set-C optional
+integrations are now authored + built** (Set C is no longer "to author"); `spider-client`,
+`assemblyai`, and `impit` are all present + `build=success`; only `firecrawl-py` lacks a build
+record. The residual work is therefore **skew-fix → re-verify GREEN → leaves-first submission**,
+not authoring. It also **resolved all five open questions** (Q1 single 3-output recipe / no split;
+Q2 ragstack local-only commented-out; Q3 python_min 3.11; Q4 apify-client attempt-or-drop; Q5
+langchain-elasticsearch gated on cf `elasticsearch-feedstock` PR #122) and recorded the **Skew 1
+approach** (local langchain rebuild first to verify GREEN, then the upstream feedstock PR).
+Execution (Waves A–D) is unstarted and gated on explicit per-action go-ahead; no pushes/PRs yet.


### PR DESCRIPTION
Updates the **intake spec** `docs/specs/langflow-conda-forge.md` to be current with the 2026-06-23 ultraplan re-grounding. Spec only — **no recipe changes, no execution**; `status:` stays `ready` (intake complete, unimplemented).

## What changed

**Grounding corrections (live `recipes/` scan):**
- All ~18 **Set-C optional integrations are now authored + present** — the spec's "not yet authored" claim was stale. Wave C becomes *re-verify + submit*, not *author + submit*.
- `spider-client`, `assemblyai`, `impit` are all present + `build=success`.
- Only `firecrawl-py` lacks a build record (build in Wave A).
- Residual work reframed: **skew-fix → re-verify GREEN → leaves-first submission** (authoring is effectively complete).

**Open questions Q1–Q5 resolved (rxm7706):**
- **Q1** — keep the **single 3-output `langflow-suite` recipe** (lfx/langflow-base/langflow version-locked); do **not** split lfx. The `langflow → lfx-* → lfx` bootstrap cycle is handled by sequencing + a temporary `langflow`-output test relaxation (Wave B6→B7→B8 follow-up).
- **Q2** — `ragstack-ai-knowledge-store` kept **local-only, commented-out** (BUSL-1.1 / non-OSI); never submit.
- **Q3** — declare **`python_min 3.11`** across the suite (G41).
- **Q4** — `apify-client` **attempt** (impit now built; G38 py311 verify), drop if it can't be unblocked.
- **Q5** — `langchain-elasticsearch` **gated on** `conda-forge/elasticsearch-feedstock` [PR #122](https://github.com/conda-forge/elasticsearch-feedstock/pull/122).

**Skew 1 approach recorded:** local `langchain` rebuild first to verify the 3-output suite goes test-GREEN (py3.11), then the ~1-line upstream `langchain-feedstock` pin PR.

Sections touched: frontmatter, Status, Packaging shape (Q1), Submission sets B/C, Caveats, External Skew 1, Waved plan (A1/B6–B8/C), Open Questions, Worked Example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUNsHLH2kN7vaQkcS9ZBrU)_