### PR TITLE
docs(specs): add Recipe Registry & Submission Tracker appendix

### DIFF
--- a/docs/specs/langflow-conda-forge.md
+++ b/docs/specs/langflow-conda-forge.md
@@ -146,6 +146,8 @@ grandalf, mcp, cryptography, …).
 | agent-lifecycle-toolkit | blocked-pending-prereq | noarch | Apache-2.0 | ibm-watsonx-ai, smolagents, llm-sandbox (import `altk`, G7) |
 | opendsstar | blocked-pending-prereq | noarch | Apache-2.0 | pymilvus-model, milvus-lite, langchain-milvus, smolagents, ragworkbench (import `OpenDsStar`, G7) |
 | firecrawl-py | (built) | noarch | MIT | — (langflow-base hard dep) |
+| spider-client | pending-submission | noarch | MIT | — (leaf; langflow-base hard dep) |
+| assemblyai | pending-submission | noarch | MIT | — (leaf; langflow-base hard dep) |
 | **lfx** *(SPLIT OUT — own feedstock)* | blocked-pending-prereq | noarch | MIT | langflow-sdk, opendsstar, jsonquerylang, markitdown(cf), langchain+langchain-classic(cf) |
 | lfx-arxiv | blocked-pending-prereq | noarch | MIT | lfx |
 | lfx-docling | blocked-pending-prereq | noarch | MIT | lfx, docling-core(cf) |

--- a/docs/specs/langflow-conda-forge.md
+++ b/docs/specs/langflow-conda-forge.md
@@ -371,3 +371,104 @@ Q2 ragstack local-only commented-out; Q3 python_min 3.11; Q4 apify-client attemp
 langchain-elasticsearch gated on cf `elasticsearch-feedstock` PR #122) and recorded the **Skew 1
 approach** (local langchain rebuild first to verify GREEN, then the upstream feedstock PR).
 Execution (Waves A–D) is unstarted and gated on explicit per-action go-ahead; no pushes/PRs yet.
+
+---
+
+## Appendix: Recipe Registry & Submission Tracker
+
+Every local recipe in the langflow-suite closure, with its wave, current status, and submission PR.
+Recipe links point at `main`. **As of 2026-06-23 execution is unstarted — no submissions yet, so
+every PR cell is `—`.** Fill each PR cell as a recipe is submitted, e.g.
+`[#33846](https://github.com/conda-forge/staged-recipes/pull/33846)`. Keep this table the
+single source of truth for "where is each recipe in the pipeline".
+
+Status legend (mirrors the recipe's `cfe-on-conda-forge-status`):
+**ready** = `pending-submission-to-conda-forge` (built GREEN, no blockers) ·
+**blocked** = `blocked-pending-prerequisites` (built clean locally; gated on a prereq/skew) ·
+**not-built** = authored, no local build record yet ·
+**local-only** = never submit (license/eligibility).
+
+### Wave B — core hard-dep closure (leaves → roots)
+
+| Recipe | Wave | recipe.yaml | Status | Submission PR |
+|---|---|---|---|---|
+| primp | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/primp/recipe.yaml) | ready | — |
+| jsonquerylang | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/jsonquerylang/recipe.yaml) | ready | — |
+| langflow-sdk | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langflow-sdk/recipe.yaml) | ready | — |
+| jigsawstack | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/jigsawstack/recipe.yaml) | ready | — |
+| smolagents | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/smolagents/recipe.yaml) | ready | — |
+| llm-sandbox | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/llm-sandbox/recipe.yaml) | ready | — |
+| pybase62 | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/pybase62/recipe.yaml) | ready | — |
+| lomond | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/lomond/recipe.yaml) | ready | — |
+| apify-shared | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/apify-shared/recipe.yaml) | ready | — |
+| vlmrun-hub | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/vlmrun-hub/recipe.yaml) | ready | — |
+| ibm-cos-sdk-core | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ibm-cos-sdk-core/recipe.yaml) | ready | — |
+| pymilvus-model | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/pymilvus-model/recipe.yaml) | ready | — |
+| milvus-lite | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/milvus-lite/recipe.yaml) | ready | — |
+| couchbase | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/couchbase/recipe.yaml) | ready | — |
+| firecrawl-py | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/firecrawl-py/recipe.yaml) | not-built (build in Wave A) | — |
+| trustcall | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/trustcall/recipe.yaml) | blocked | — |
+| qianfan | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/qianfan/recipe.yaml) | blocked | — |
+| ragworkbench | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ragworkbench/recipe.yaml) | blocked | — |
+| toolguard | B1 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/toolguard/recipe.yaml) | blocked | — |
+| pksuid | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/pksuid/recipe.yaml) | blocked (→pybase62) | — |
+| vlmrun | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/vlmrun/recipe.yaml) | blocked (→vlmrun-hub) | — |
+| ddgs | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ddgs/recipe.yaml) | blocked (→primp) | — |
+| langchain-milvus | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-milvus/recipe.yaml) | ready | — |
+| ibm-cos-sdk-s3transfer | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ibm-cos-sdk-s3transfer/recipe.yaml) | blocked (→core) | — |
+| langwatch | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langwatch/recipe.yaml) | blocked (→pksuid, pybase62) | — |
+| spider-client | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/spider-client/recipe.yaml) | ready | — |
+| assemblyai | B2 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/assemblyai/recipe.yaml) | ready | — |
+| ibm-cos-sdk | B3 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ibm-cos-sdk/recipe.yaml) | blocked (→core + s3transfer) | — |
+| ibm-watsonx-ai | B4 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ibm-watsonx-ai/recipe.yaml) | blocked (→ibm-cos-sdk; also build 1.3.37 for py3.10, G40) | — |
+| langchain-ibm | B5 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-ibm/recipe.yaml) | blocked (→ibm-watsonx-ai) | — |
+| agent-lifecycle-toolkit | B5 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/agent-lifecycle-toolkit/recipe.yaml) | blocked (→ibm-watsonx-ai, smolagents, llm-sandbox) | — |
+| opendsstar | B5 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/opendsstar/recipe.yaml) | blocked (→pymilvus-model, milvus-lite, langchain-milvus, smolagents, ragworkbench) | — |
+| **langflow-suite** (lfx + langflow-base + langflow) | B6 / B8 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langflow-suite/recipe.yaml) | blocked (Skew 1; 3-output submission unit) | — |
+| lfx-arxiv | B7 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/lfx-arxiv/recipe.yaml) | blocked (→lfx) | — |
+| lfx-docling | B7 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/lfx-docling/recipe.yaml) | blocked (→lfx, docling-core) | — |
+| lfx-duckduckgo | B7 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/lfx-duckduckgo/recipe.yaml) | blocked (→lfx, ddgs) | — |
+| lfx-ibm | B7 | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/lfx-ibm/recipe.yaml) | blocked (→lfx, langchain-ibm, ibm-watsonx-ai) | — |
+
+> **Folded into `langflow-suite`** (Q1 — single 3-output recipe; these dirs are kept for *local*
+> build-verification only, NOT submitted standalone):
+> [lfx](https://github.com/rxm7706/local-recipes/blob/main/recipes/lfx/recipe.yaml) ·
+> [langflow-base](https://github.com/rxm7706/local-recipes/blob/main/recipes/langflow-base/recipe.yaml) ·
+> [langflow](https://github.com/rxm7706/local-recipes/blob/main/recipes/langflow/recipe.yaml).
+
+### Wave C — optional integrations (`run_constraints`)
+
+| Recipe | Wave | recipe.yaml | Status | Submission PR |
+|---|---|---|---|---|
+| langchain-astradb | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-astradb/recipe.yaml) | blocked (→astrapy, cassio) | — |
+| langchain-graph-retriever | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-graph-retriever/recipe.yaml) | blocked | — |
+| langchain-google-vertexai | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-google-vertexai/recipe.yaml) | blocked | — |
+| langchain-sambanova | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-sambanova/recipe.yaml) | blocked | — |
+| langchain-google-community | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-google-community/recipe.yaml) | blocked (G12 numpy-selector, G35) | — |
+| ag2 | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ag2/recipe.yaml) | ready | — |
+| astrapy | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/astrapy/recipe.yaml) | ready | — |
+| cassio | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/cassio/recipe.yaml) | ready | — |
+| cleanlab-tlm | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/cleanlab-tlm/recipe.yaml) | ready | — |
+| composio-langchain | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/composio-langchain/recipe.yaml) | ready | — |
+| langchain-cohere | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-cohere/recipe.yaml) | ready | — |
+| langchain-google-calendar-tools | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-google-calendar-tools/recipe.yaml) | ready | — |
+| langchain-nvidia-ai-endpoints | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-nvidia-ai-endpoints/recipe.yaml) | ready | — |
+| langchain-pinecone | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-pinecone/recipe.yaml) | ready | — |
+| langchain-unstructured | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-unstructured/recipe.yaml) | ready | — |
+| langchain-weaviate | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-weaviate/recipe.yaml) | ready | — |
+| mem0ai | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/mem0ai/recipe.yaml) | not-built | — |
+| metal-sdk | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/metal-sdk/recipe.yaml) | ready | — |
+| needle-python | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/needle-python/recipe.yaml) | ready | — |
+| openlayer | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/openlayer/recipe.yaml) | ready | — |
+| opik | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/opik/recipe.yaml) | blocked (Skew 3 otel) | — |
+| scrapegraph-py | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/scrapegraph-py/recipe.yaml) | ready | — |
+| upstash-vector | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/upstash-vector/recipe.yaml) | ready | — |
+
+### Caveats / special handling
+
+| Recipe | Wave | recipe.yaml | Status | Submission PR |
+|---|---|---|---|---|
+| impit | C (prereq) | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/impit/recipe.yaml) | ready (compiled; unblocks apify-client, G38) | — |
+| apify-client | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/apify-client/recipe.yaml) | blocked (→impit; **attempt, may drop**) | — |
+| langchain-elasticsearch | C | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/langchain-elasticsearch/recipe.yaml) | blocked (gated on [elasticsearch-feedstock #122](https://github.com/conda-forge/elasticsearch-feedstock/pull/122)) | — |
+| ragstack-ai-knowledge-store | — | [recipe.yaml](https://github.com/rxm7706/local-recipes/blob/main/recipes/ragstack-ai-knowledge-store/recipe.yaml) | **local-only — NEVER submit** (BUSL-1.1 / non-OSI) | n/a |

--- a/docs/specs/langflow-conda-forge.md
+++ b/docs/specs/langflow-conda-forge.md
@@ -1,8 +1,8 @@
 ---
 status: ready
 implemented_by: bmad-quick-dev
-shipped_ref: "full local closure built GREEN; conda-forge submission + skew-fix unimplemented"
-scope: full-closure   # core hard-dep closure + ALL optional run_constraints integrations (incl. ~20 not-yet-authored) + ALL 3 external cf skews. Nothing deferred except the 3 named caveats.
+shipped_ref: "full local closure built GREEN (incl. ALL Set-C integrations now authored); conda-forge submission + skew-fix unimplemented; ultraplan-grounded + Q1–Q5 resolved 2026-06-23"
+scope: full-closure   # core hard-dep closure + ALL optional run_constraints integrations (Set C now ALL authored locally) + ALL 3 external cf skews. Nothing deferred except the 3 named caveats (handled per § Caveats: elasticsearch gated on cf PR #122; apify-client attempt-or-drop; ragstack kept local-only).
 spec_updated: 2026-06-23
 ---
 # Tech Spec: langflow-suite on conda-forge (submission + external-skew remediation)
@@ -53,7 +53,7 @@ spec_updated: 2026-06-23
 
 | Field | Value |
 | ----- | ----- |
-| Status | **Local closure built GREEN; conda-forge submission not started; langflow-suite test-blocked on one external cf skew.** All ~46 prerequisite recipes are authored and built into the local channel; `recipes/langflow-suite/` builds clean for all 3 outputs (`--test skip` GREEN, 2026-06-23). The langflow-suite test-env solve is blocked by the **langchain-text-splitters** skew (§ External Skews). |
+| Status | **Local closure built GREEN; conda-forge submission not started; langflow-suite test-blocked on one external cf skew.** All ~46 core prerequisite recipes AND **all ~18 Set-C optional integrations are now authored + built** into the local channel (ultraplan re-grounding, 2026-06-23 — Set C is no longer "to author"; `spider-client`, `assemblyai`, `impit` are all present + `build=success`). `recipes/langflow-suite/` builds clean for all 3 outputs (`--test skip` GREEN, 2026-06-23). The langflow-suite test-env solve is blocked by the **langchain-text-splitters** skew (§ External Skews). **Residual work is now skew-fix → re-verify GREEN → leaves-first submission** (authoring is effectively complete). Only `firecrawl-py` lacks a build record and needs a verification build. |
 | Owner | rxm7706 |
 | Track | BMAD Quick Flow (tech-spec only) |
 | Upstream | `langflow-ai/langflow` v1.10.0 (MIT). Monorepo split into `lfx` (executor core, `src/lfx`), `langflow-base` (`src/backend/base`, ships the `langflow` import), `langflow` (umbrella, `.`), and the `lfx-*` extension plugins. |
@@ -73,13 +73,19 @@ spec_updated: 2026-06-23
 - **The 4 `lfx-*` extension plugins are SEPARATE feedstocks** (`lfx-arxiv`, `lfx-docling`,
   `lfx-duckduckgo`, `lfx-ibm`). The `langflow` umbrella **hard-deps** all four
   (upstream `langflow` `[project.dependencies]` = `langflow-base[complete]` + the 4 `lfx-*`).
-- **⚠ Cross-feedstock cycle → split `lfx` out (Open Question Q1).** `langflow` (a suite output)
-  hard-deps the 4 `lfx-*`; each `lfx-*` deps `lfx` (also a suite output). A single suite feedstock
-  cannot satisfy "lfx on cf → lfx-* on cf → langflow tests" in one shot. **Recommended submission
-  shape: split `lfx` into its own feedstock submitted first**, then `lfx-*`, then a
-  `langflow-base`+`langflow` recipe (2-output suite, or two recipes). The current single
-  3-output recipe is fine for *local* build verification but not for the staged-recipes
-  dependency order.
+- **⚠ Cross-feedstock cycle → KEEP the single 3-output recipe (Q1 RESOLVED — do NOT split).**
+  `langflow` (a suite output) hard-deps the 4 `lfx-*`; each `lfx-*` deps `lfx` (also a suite
+  output). **Decision (rxm7706, 2026-06-23):** keep the **single 3-output `langflow-suite`
+  recipe** (lfx + langflow-base + langflow) so the three versions stay locked together — better
+  long-term (one feedstock; autotick bumps lfx/langflow-base/langflow in lockstep). This
+  overrides the earlier "split lfx out" recommendation.
+  The residual is a **bootstrap cycle at the *initial* staged-recipes gate**: `langflow`'s
+  test-env solve needs the 4 separate `lfx-*` feedstocks, which need `lfx` (a suite output not
+  yet on cf). **Mitigation = sequencing + a temporary test relaxation, NOT splitting:** submit
+  the 3-output suite first so `lfx` publishes → submit the 4 `lfx-*` (now `lfx` is on cf) →
+  build-number-bump follow-up to tighten/enable `langflow`'s full test (or relax just the
+  `langflow` output's lfx-* import test on the first submission, then re-enable). Once all are
+  on cf the single-feedstock shape is exactly what's wanted.
 - **Dependency lists come from upstream pyproject, not the hand-authored recipe lists.** Earlier
   the recipe's output `run:` lists diverged from upstream (e.g. fabricated `atlaspy`/`dynamicconf`;
   truncated `lfx` deps). For each output, flatten the real upstream `[project.dependencies]`
@@ -153,32 +159,44 @@ grandalf, mcp, cryptography, …).
 | **langflow-base** *(suite)* | blocked-pending-prereq | noarch | MIT | lfx, jsonquerylang, spider-client, assemblyai, firecrawl-py, langchain stack |
 | **langflow** *(suite)* | blocked-pending-prereq | noarch | MIT | langflow-base[complete], lfx-arxiv, lfx-docling, lfx-duckduckgo, lfx-ibm |
 
-> **Re-verify before each wave:** the `langflow-base` and `langflow` hard-dep closures include
-> a few more net-new packages not yet scanned/authored (notably **`spider-client`** and
-> **`assemblyai`**, both langflow-base BASE deps, missing from cf). BMAD must flatten each
-> output's real upstream `[project.dependencies]` (umbrella also `langflow-base[complete]`, G25),
-> run `check_dependencies` on the flattened recipe (G29), and author any still-missing leaf before
-> that wave.
+> **Re-verify before each wave:** **`spider-client`** and **`assemblyai`** (both langflow-base
+> BASE deps) are now **authored + `build=success` locally** (ultraplan scan 2026-06-23) — no
+> longer "to author". BMAD must still flatten each output's real upstream `[project.dependencies]`
+> (umbrella also `langflow-base[complete]`, G25), run `check_dependencies` on the **flattened
+> single-output** recipe (G29 — multi-output checkers are top-level-only), and author any
+> still-missing leaf before that wave. Only `firecrawl-py` currently lacks a `cfe-local-build-*`
+> record — build + verify it in Wave A.
 
 ### C. Optional integrations (`run_constraints`) — full-closure scope
 
 Soft constraints; they do not block langflow-suite install, but the full suite experience wants
-them on cf. Already-built (submit in Wave C): the 5 `langchain-*` in table B above marked as
-already authored. **Not yet authored — author + submit:** `ag2`, `assemblyai`, `astrapy`,
-`cassio`, `cleanlab-tlm`, `composio-langchain`, `langchain-cohere`,
-`langchain-google-calendar-tools`, `langchain-nvidia-ai-endpoints`, `langchain-pinecone`,
-`langchain-unstructured`, `langchain-weaviate`, `mem0ai`, `metal-sdk`, `needle-python`,
-`openlayer`, `opik`, `scrapegraph-py`, `spider-client`, `upstash-vector`.
+them on cf. **CORRECTION (ultraplan scan 2026-06-23): the entire Set-C list below is now AUTHORED
++ present locally** — the spec's earlier "not yet authored" claim is stale. Authoring is
+effectively complete; Wave C is now **re-verify each leaf → submit leaves-first**, not "author +
+submit". Set C (all present): `ag2`, `astrapy`, `cassio`, `cleanlab-tlm`, `composio-langchain`,
+`langchain-cohere`, `langchain-google-calendar-tools`, `langchain-nvidia-ai-endpoints`,
+`langchain-pinecone`, `langchain-unstructured`, `langchain-weaviate`, `mem0ai`, `metal-sdk`,
+`needle-python`, `openlayer`, `opik`, `scrapegraph-py`, `upstash-vector` — plus the 5 already-built
+`langchain-*` in table B and the now-relocated-to-B `spider-client` + `assemblyai` (langflow-base
+hard deps, not optional). Submit each leaf (SDK) before its `langchain-*` wrapper; re-run
+`check_dependencies` per leaf since each carries its own recursive sub-closure. Skews 2 + 3 gate
+this wave (not the core suite).
 
-### Caveats (special handling — do NOT submit naively)
+### Caveats (special handling — do NOT submit naively) — RESOLVED 2026-06-23
 
-- **`ragstack-ai-knowledge-store` — BUSL-1.1, NOT conda-forge-eligible** (non-OSI). Drop from the
-  submission set; confirm `opendsstar` resolves without it (Q2).
+- **`ragstack-ai-knowledge-store` — BUSL-1.1, NOT conda-forge-eligible** (non-OSI). **Q2 RESOLVED:**
+  **keep the recipe locally** (it's present) **but commented-out / clearly marked
+  `BUSL-1.1 / non-OSI — out of scope for conda-forge`; NEVER submit.** Confirm `opendsstar`
+  resolves without it (is it a hard or optional opendsstar dep? — verify in Wave A).
 - **`langchain-elasticsearch` — blocked on a cf gap:** requires `elasticsearch >=8.19,<9` which
-  does not exist on conda-forge (feedstock jumps 8.18.0 → 9.0.0). File an `elasticsearch-feedstock`
-  version-bump request, or drop (Q5).
-- **`apify-client` — blocked on `impit` py311+** (G38: `impit` is compiled, only py310 in the
-  local channel). Build `impit` for the py311+ matrix, or drop `apify-client` (Q4).
+  did not exist on conda-forge (feedstock jumps 8.18.0 → 9.0.0). **Q5 RESOLVED: INCLUDE, gated on
+  the live `elasticsearch-feedstock` bump — `conda-forge/elasticsearch-feedstock` PR #122
+  (https://github.com/conda-forge/elasticsearch-feedstock/pull/122) is UP.** Submit
+  `langchain-elasticsearch` once #122 merges and `elasticsearch >=8.19` is on cf.
+- **`apify-client` — was blocked on `impit` py311+** (G38). **Q4 RESOLVED: ATTEMPT — `impit` is now
+  present + `build=success` locally.** Verify `impit` covers the consumer's py3.11 matrix (G38),
+  then include `apify-client`. **Flag as at-risk: if it can't be unblocked cleanly, DROP it**
+  (optional integration; dropping is acceptable).
 
 ---
 
@@ -202,6 +220,11 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
   `langchain-text-splitters` run-dep so it admits `>=1.1.0` (match upstream + `langchain-classic`),
   rerender, merge. **Verify first** against the exact cf-pinned 1.2.x upstream metadata
   (`pypi.org/pypi/langchain/<ver>/json`).
+- **Approach RESOLVED (rxm7706, 2026-06-23): local rebuild FIRST, then the upstream PR.** Rebuild
+  `langchain` locally with the loosened text-splitters pin to confirm `lfx` + the 3-output
+  `langflow-suite` go **test-GREEN on the py3.11 leg** fast (no outward action / no waiting on
+  external review). THEN file the ~1-line `conda-forge/langchain-feedstock` PR as the durable fix.
+  The local rebuild is the iteration loop; the upstream PR is what actually unblocks cf submission.
 - **Note:** `langchain 1.2.x` is NOT py3.13-only — it has `pymin310` builds (`python >=3.10,<3.13`)
   covering py3.11; Python is not the blocker, the text-splitters pin is.
 - **Diagnosis test:** solve `langchain` + `langchain-classic` + `langchain-text-splitters` in
@@ -233,10 +256,13 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 
 ### Wave A — clear the external skews (gate to langflow-suite test-GREEN)
 
-- **A1 — langchain-text-splitters (Skew 1).** File + land the `langchain-feedstock` text-splitters
-  pin fix. This is the **only** skew blocking the core suite. After it merges (or via a local
-  langchain rebuild for fast iteration), re-attempt `langflow-suite` → require all 3 outputs
-  build + test GREEN (py3.11 leg). Flip cfe-status to `pending-submission-to-conda-forge`.
+- **A1 — langchain-text-splitters (Skew 1).** **Local rebuild FIRST** (resolved approach): rebuild
+  `langchain` locally with the loosened text-splitters pin → rebuild `lfx` → re-attempt the
+  3-output `langflow-suite` → require all 3 outputs **build + test GREEN (py3.11 leg)**. This is the
+  **only** skew blocking the core suite. THEN file + land the `conda-forge/langchain-feedstock`
+  ~1-line pin fix (the durable unblock for cf submission). Also in A1: **build + verify
+  `firecrawl-py`** (only closure recipe lacking a build record), and confirm `opendsstar` resolves
+  without `ragstack-ai-knowledge-store`. Flip affected cfe-status to `pending-submission-to-conda-forge`.
 - **A2 — litellm/fastapi (Skew 2)** and **A3 — otel cluster (Skew 3).** Needed only for the
   optional-integration closure (Wave C). Drive in parallel; not a gate for Wave B.
 
@@ -252,19 +278,28 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 4. **B4:** ibm-watsonx-ai (→ibm-cos-sdk); also build 1.3.37 for the py3.10 leg (G40).
 5. **B5:** langchain-ibm (→ibm-watsonx-ai), agent-lifecycle-toolkit (→ibm-watsonx-ai, smolagents,
    llm-sandbox), opendsstar (→pymilvus-model, milvus-lite, langchain-milvus, smolagents, ragworkbench).
-6. **B6:** **lfx** (own feedstock — Q1) → langflow-sdk, opendsstar, jsonquerylang + cf langchain stack.
-7. **B7:** lfx-arxiv, lfx-docling, lfx-duckduckgo (→ddgs), lfx-ibm (→langchain-ibm, ibm-watsonx-ai)
-   — all → lfx.
-8. **B8:** langflow-base (→lfx, spider-client, assemblyai, firecrawl-py) + langflow
-   (→langflow-base[complete], the 4 lfx-*). Ship as a 2-output suite or two recipes (Q1).
+6. **B6 (single 3-output suite — Q1 RESOLVED, NOT split):** submit `recipes/langflow-suite/`
+   producing **lfx + langflow-base + langflow** in one PR (→ langflow-sdk, opendsstar,
+   jsonquerylang, spider-client, assemblyai, firecrawl-py + cf langchain stack). Because the 4
+   `lfx-*` feedstocks aren't on cf yet, **temporarily relax the `langflow` output's lfx-* import
+   test** for this first submission (the bootstrap cycle — see § Packaging shape). This publishes
+   `lfx`.
+7. **B7:** submit the 4 `lfx-*` feedstocks (now that `lfx` is on cf): lfx-arxiv, lfx-docling,
+   lfx-duckduckgo (→ddgs), lfx-ibm (→langchain-ibm, ibm-watsonx-ai) — all → lfx.
+8. **B8 (follow-up):** build-number-bump PR on `langflow-suite` to **re-enable / tighten the
+   `langflow` output's full lfx-* test** now that all 4 `lfx-*` are on cf. Suite versions stay
+   locked together from here on (autotick maintains lfx/langflow-base/langflow in lockstep).
 
 ### Wave C — submit optional integrations (full-closure scope)
 
 - Submit the already-built `langchain-*` (astradb, graph-retriever, google-vertexai, sambanova,
   google-community) once their SDK leaves are on cf.
-- Author + submit the not-yet-authored set (§ Submission set C), leaves-first (SDK leaf before its
-  `langchain-*` wrapper). Resolve the 3 caveats (ragstack drop; langchain-elasticsearch /
-  elasticsearch>=8.19; apify-client / impit py311).
+- **Re-verify + submit** the rest of Set C (§ Submission set C) — **all now authored** — leaves-first
+  (SDK leaf before its `langchain-*` wrapper); re-run `check_dependencies` per leaf.
+- Caveats (resolved): **ragstack** kept local-only, commented-out (BUSL-1.1/non-OSI — never submit);
+  **langchain-elasticsearch** submitted once `elasticsearch-feedstock` PR #122 merges
+  (elasticsearch >=8.19 on cf); **apify-client** attempted (impit built — G38 py311 verify), dropped
+  if it can't be unblocked.
 
 ### Wave D — closeout
 
@@ -293,20 +328,23 @@ langflow-base → langflow.
 
 ---
 
-## Open Questions
+## Open Questions — ALL RESOLVED 2026-06-23 (rxm7706, via ultraplan)
 
-- **Q1 — suite shape (recommend split lfx).** Submit `lfx` as its own feedstock first (breaks the
-  `langflow → lfx-* → lfx` cycle), keep `langflow-base`+`langflow` as a 2-output suite — vs. forcing
-  the single 3-output recipe through staged-recipes (cannot satisfy the cycle in one PR). Spec
-  recommends the split.
-- **Q2 — ragstack-ai-knowledge-store BUSL-1.1.** Non-OSI → drop from the cf set; confirm `opendsstar`
-  resolves without it (is it a hard or optional opendsstar dep?).
-- **Q3 — python_min 3.11.** Confirm reviewers accept langflow declaring `python_min 3.11` (the honest
-  floor per G41; upstream `requires-python>=3.10` is broken).
-- **Q4 — apify-client / impit.** Build `impit` for the py311+ matrix (G38), or drop `apify-client`
-  (optional integration).
-- **Q5 — langchain-elasticsearch / elasticsearch ≥8.19.** File an `elasticsearch-feedstock`
-  version-bump request, or drop the integration.
+- **Q1 — suite shape. RESOLVED: KEEP the single 3-output recipe (do NOT split lfx).** lfx +
+  langflow-base + langflow ship from one `langflow-suite` feedstock so the three versions stay
+  locked together (better long-term; autotick bumps them in lockstep). The `langflow → lfx-* → lfx`
+  bootstrap cycle is handled at the *initial* staged-recipes gate by **sequencing + a temporary
+  relaxation of the `langflow` output's lfx-* test** (Wave B6 → B7 → B8 follow-up), not by splitting.
+- **Q2 — ragstack-ai-knowledge-store BUSL-1.1. RESOLVED: keep the recipe LOCAL-ONLY, commented-out,
+  marked non-OSI/out-of-scope; NEVER submit.** Confirm `opendsstar` resolves without it (Wave A).
+- **Q3 — python_min 3.11. RESOLVED: declare `python_min 3.11` across the suite** (honest floor per
+  G41 — jsonquerylang hard-imports `typing.NotRequired`/PEP 655; upstream `requires-python>=3.10` is
+  broken). Reviewer pushback is answerable.
+- **Q4 — apify-client / impit. RESOLVED: ATTEMPT** (impit now present + `build=success`; verify py3.11
+  matrix per G38), **flag at-risk; DROP if it can't be unblocked cleanly.**
+- **Q5 — langchain-elasticsearch / elasticsearch ≥8.19. RESOLVED: INCLUDE, gated on
+  `conda-forge/elasticsearch-feedstock` PR #122**
+  (https://github.com/conda-forge/elasticsearch-feedstock/pull/122, UP). Submit once #122 merges.
 
 ---
 
@@ -319,3 +357,15 @@ Build-Failure-Protocol note (shipped CFE v8.35.0). The 2026-06-23 session fixed 
 upstream's ~43 deps with G24 caps + G25 `httpx[http2]` flatten), confirmed **all 3 outputs build
 GREEN** (`--test skip`), and pinned the residual blocker to **Skew 1 (langchain-text-splitters)** —
 a stale `langchain-feedstock` pin, the precise fix for which is Wave A1.
+
+The **2026-06-23 ultraplan re-grounding** session (this update) read the spec in full under the
+`conda-forge-expert` skill, **re-scanned `recipes/` against the closure**, and found the repo
+materially ahead of the spec's prose: **all ~46 core recipes AND all ~18 Set-C optional
+integrations are now authored + built** (Set C is no longer "to author"); `spider-client`,
+`assemblyai`, and `impit` are all present + `build=success`; only `firecrawl-py` lacks a build
+record. The residual work is therefore **skew-fix → re-verify GREEN → leaves-first submission**,
+not authoring. It also **resolved all five open questions** (Q1 single 3-output recipe / no split;
+Q2 ragstack local-only commented-out; Q3 python_min 3.11; Q4 apify-client attempt-or-drop; Q5
+langchain-elasticsearch gated on cf `elasticsearch-feedstock` PR #122) and recorded the **Skew 1
+approach** (local langchain rebuild first to verify GREEN, then the upstream feedstock PR).
+Execution (Waves A–D) is unstarted and gated on explicit per-action go-ahead; no pushes/PRs yet.


### PR DESCRIPTION
Adds an **Appendix: Recipe Registry & Submission Tracker** to the intake spec.

Lists every local recipe in the langflow-suite closure with:
- a link to its `recipe.yaml` on `main`,
- **wave** (B core / C optional / caveats),
- **current status** (mapped from each recipe's `cfe-on-conda-forge-status`),
- a **Submission PR** column — all `—` for now (execution unstarted), to be filled as recipes are submitted, e.g. `[#33846](https://github.com/conda-forge/staged-recipes/pull/33846)`.

Grouped Wave B (leaves→roots) / Wave C / Caveats. Notes that `lfx`/`langflow-base`/`langflow` dirs are folded into `langflow-suite` (Q1 single 3-output recipe) and kept only for local build-verification. `ragstack-ai-knowledge-store` flagged local-only (never submit). Intended as the single source of truth for pipeline state.

Spec only — no recipe changes, no execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUNsHLH2kN7vaQkcS9ZBrU)_