### PR TITLE
chore: record firecrawl-py + mem0ai local-build verification (full cfe block)

### DIFF
--- a/recipes/firecrawl-py/recipe.yaml
+++ b/recipes/firecrawl-py/recipe.yaml
@@ -53,3 +53,37 @@ about:
 extra:
   recipe-maintainers:
     - rxm7706
+
+#### CFE metadata AND comments
+# CFE metadata
+  cfe-conda-name: firecrawl-py
+  cfe-upstream-registry: pypi
+  cfe-upstream-name: firecrawl-py
+  cfe-purls:
+    - pkg:conda/firecrawl-py@${{ version }}
+    - pkg:pypi/firecrawl-py@${{ version }}
+  cfe-upstream-repo: https://github.com/firecrawl/firecrawl
+  cfe-upstream-homepage: https://github.com/firecrawl/firecrawl
+  cfe-import-names: [firecrawl]
+  cfe-source-kind: pypi-sdist
+  cfe-noarch: python
+  cfe-pip-check: true
+  cfe-on-conda-forge-status: pending-submission-to-conda-forge
+  cfe-on-conda-forge-feedstock: none
+  cfe-forge-recipe-updates-needed: none
+  cfe-forge-blocker-list: []
+  cfe-last-checked: 2026-06-23T10:49:42Z
+  cfe-generated-by-version: 8.42.0
+  cfe-generated-at-datetime: 2026-06-23T10:49:42Z
+  cfe-local-build-status: success
+  cfe-local-build-datetime: 2026-06-23T10:49:42Z
+  cfe-local-build-platform: linux-64
+  cfe-local-build-tool: rattler-build
+####
+# CFE comments
+# requirements:
+#  run:
+#    # pytest + pytest-asyncio are in upstream's runtime dependency list (not a
+#    # test extra), so pip_check: true REQUIRES them — dropping them reds out
+#    # pip_check (G24). Left in place to mirror the wheel METADATA.
+####

--- a/recipes/mem0ai/recipe.yaml
+++ b/recipes/mem0ai/recipe.yaml
@@ -62,3 +62,30 @@ about:
 extra:
   recipe-maintainers:
     - rxm7706
+
+#### CFE metadata AND comments
+# CFE metadata
+  cfe-conda-name: mem0ai
+  cfe-upstream-registry: pypi
+  cfe-upstream-name: mem0ai
+  cfe-purls:
+    - pkg:conda/mem0ai@${{ version }}
+    - pkg:pypi/mem0ai@${{ version }}
+  cfe-upstream-repo: https://github.com/mem0ai/mem0
+  cfe-upstream-homepage: https://docs.mem0.ai
+  cfe-import-names: [mem0]
+  cfe-source-kind: pypi-sdist
+  cfe-noarch: python
+  cfe-pip-check: true
+  cfe-on-conda-forge-status: pending-submission-to-conda-forge
+  cfe-on-conda-forge-feedstock: none
+  cfe-forge-recipe-updates-needed: none
+  cfe-forge-blocker-list: []
+  cfe-last-checked: 2026-06-23T10:49:42Z
+  cfe-generated-by-version: 8.42.0
+  cfe-generated-at-datetime: 2026-06-23T10:49:42Z
+  cfe-local-build-status: success
+  cfe-local-build-datetime: 2026-06-23T10:49:42Z
+  cfe-local-build-platform: linux-64
+  cfe-local-build-tool: rattler-build
+####


### PR DESCRIPTION
Addresses the #23 registry comment: `firecrawl-py` and `mem0ai` were marked **not-built** (no local build record).

> **Rebased to recipe-files-only.** The spec-side flip (`not-built` → `ready (built PR#24)`) already landed via #26, so the `docs/specs/langflow-conda-forge.md` hunk — which is what made this PR `CONFLICTING` — has been dropped. This PR now touches **only `recipes/`**, so it no longer needs a `maintenance` label and the `docs/specs` half is non-conflicting (already on `main`).

## What changed
Verified both build+test **GREEN** locally (rattler-build, linux-64, 2026-06-23):

| Recipe | Result |
|---|---|
| `firecrawl-py` 4.3.6 | import `firecrawl` ✓, pip_check ✓, EXIT 0 |
| `mem0ai` 2.0.4 | import `mem0` ✓, pip_check ✓ (py3.11 + `*` legs), EXIT 0 |

Both resolve entirely from conda-forge (no local-only prereq, no skew) → independently submittable.

Adds the **full canonical `extra.cfe-*` block** to each recipe (they had **no** cfe block on `main`; the earlier draft of this PR added only a 6-field stub):
- identity — `cfe-conda-name`, `cfe-upstream-registry/name`, `cfe-purls`, `cfe-upstream-repo/homepage`
- the 4 decision fields — `cfe-import-names` (`firecrawl` / `mem0`), `cfe-source-kind: pypi-sdist`, `cfe-noarch: python`, `cfe-pip-check: true`
- cf-status — `cfe-on-conda-forge-status: pending-submission-to-conda-forge`, feedstock `none`
- the `cfe-local-build-*` verification record (status `success`)

`firecrawl-py` also gets a parked `# CFE comments` note: `pytest` + `pytest-asyncio` are in upstream's **runtime** dependency list (not a test extra), so `pip_check: true` requires them — dropping them reds out pip_check (G24).

All `cfe-*` keys are stripped before any push to staged-recipes / a feedstock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)