### PR TITLE
feat: langflow-suite GREEN via lean re-architecture + skew workarounds

### DIFF
--- a/docs/specs/langflow-conda-forge.md
+++ b/docs/specs/langflow-conda-forge.md
@@ -1,7 +1,7 @@
 ---
 status: ready
 implemented_by: bmad-quick-dev
-shipped_ref: "full local closure built GREEN (incl. ALL Set-C integrations now authored); conda-forge submission + skew-fix unimplemented; ultraplan-grounded + Q1–Q5 resolved 2026-06-23"
+shipped_ref: "langflow-suite all 3 outputs (lfx+langflow-base+langflow) build+test GREEN locally (2026-06-23) via LEAN re-architecture (integrations->run_constraints) + local skew-workaround channel builds; cf-submission blocked on 2 feedstock fixes (langchain-text-splitters stale pin, litellm proxy-extras flatten)"
 scope: full-closure   # core hard-dep closure + ALL optional run_constraints integrations (Set C now ALL authored locally) + ALL 3 external cf skews. Nothing deferred except the 3 named caveats (handled per § Caveats: elasticsearch gated on cf PR #122; apify-client attempt-or-drop; ragstack kept local-only).
 spec_updated: 2026-06-23
 ---
@@ -53,7 +53,7 @@ spec_updated: 2026-06-23
 
 | Field | Value |
 | ----- | ----- |
-| Status | **Local closure built GREEN; conda-forge submission not started; langflow-suite test-blocked on one external cf skew.** All ~46 core prerequisite recipes AND **all ~18 Set-C optional integrations are now authored + built** into the local channel (ultraplan re-grounding, 2026-06-23 — Set C is no longer "to author"; `spider-client`, `assemblyai`, `impit` are all present + `build=success`). `recipes/langflow-suite/` builds clean for all 3 outputs (`--test skip` GREEN, 2026-06-23). The langflow-suite test-env solve is blocked by the **langchain-text-splitters** skew (§ External Skews). **Residual work is now skew-fix → re-verify GREEN → leaves-first submission** (authoring is effectively complete). Only `firecrawl-py` lacks a build record and needs a verification build. |
+| Status | **GREEN locally — all 3 langflow-suite outputs (lfx, langflow-base, langflow) build + test pass** (imports + pip_check, 2026-06-23) against the local channel, via the **LEAN re-architecture** (integrations → `run_constraints`; § Packaging shape) + **local skew-workaround channel builds** of `langchain` 1.2.18 / `litellm` 1.89.3 (base deps; § External skews). `cfe-local-build-status: success`. **conda-forge submission stays `blocked-pending-prerequisites`** on 2 cf feedstock fixes (langchain-text-splitters stale pin; litellm proxy-extras flatten) that gate lfx's hard deps; the local channel works around both. |
 | Owner | rxm7706 |
 | Track | BMAD Quick Flow (tech-spec only) |
 | Upstream | `langflow-ai/langflow` v1.10.0 (MIT). Monorepo split into `lfx` (executor core, `src/lfx`), `langflow-base` (`src/backend/base`, ships the `langflow` import), `langflow` (umbrella, `.`), and the `lfx-*` extension plugins. |
@@ -73,25 +73,24 @@ spec_updated: 2026-06-23
 - **The 4 `lfx-*` extension plugins are SEPARATE feedstocks** (`lfx-arxiv`, `lfx-docling`,
   `lfx-duckduckgo`, `lfx-ibm`). The `langflow` umbrella **hard-deps** all four
   (upstream `langflow` `[project.dependencies]` = `langflow-base[complete]` + the 4 `lfx-*`).
-- **⚠ Cross-feedstock cycle → KEEP the single 3-output recipe (Q1 RESOLVED — do NOT split).**
-  `langflow` (a suite output) hard-deps the 4 `lfx-*`; each `lfx-*` deps `lfx` (also a suite
-  output). **Decision (rxm7706, 2026-06-23):** keep the **single 3-output `langflow-suite`
-  recipe** (lfx + langflow-base + langflow) so the three versions stay locked together — better
-  long-term (one feedstock; autotick bumps lfx/langflow-base/langflow in lockstep). This
-  overrides the earlier "split lfx out" recommendation.
-  The residual is a **bootstrap cycle at the *initial* staged-recipes gate**: `langflow`'s
-  test-env solve needs the 4 separate `lfx-*` feedstocks, which need `lfx` (a suite output not
-  yet on cf). **Mitigation = sequencing + a temporary test relaxation, NOT splitting:** submit
-  the 3-output suite first so `lfx` publishes → submit the 4 `lfx-*` (now `lfx` is on cf) →
-  build-number-bump follow-up to tighten/enable `langflow`'s full test (or relax just the
-  `langflow` output's lfx-* import test on the first submission, then re-enable). Once all are
-  on cf the single-feedstock shape is exactly what's wanted.
-- **Dependency lists come from upstream pyproject, not the hand-authored recipe lists.** Earlier
-  the recipe's output `run:` lists diverged from upstream (e.g. fabricated `atlaspy`/`dynamicconf`;
-  truncated `lfx` deps). For each output, flatten the real upstream `[project.dependencies]`
-  (+ `langflow-base[complete]` for the umbrella, **G25** — conda has no extras), mirror upstream
-  version caps (**G24** — `pip_check` enforces them), and verify with `check_dependencies` on a
-  **flattened single-output** recipe (**G29** — the multi-output checkers are top-level-only).
+- **LEAN base + umbrella (rxm7706 directive, 2026-06-23) — integrations are NOT forced.**
+  Upstream `langflow-base` bundles ~90 integration extras and `langflow-base[complete]` pulls
+  **all** of them (= `langflow[full]`); no one needs every integration. So the recipe ships a
+  **lean** langflow-base + langflow: hard `run` = the **framework core only**; ALL integrations
+  (langchain providers, vector/analytics DB clients, external SDKs, the 4 `lfx-*` component
+  packs) are **`run_constraints`** (version-pinned, optional — constrained only if a user adds
+  them). To keep `pip_check: true` green, each output's build **`sed`-strips the integration
+  deps from the wheel METADATA** (range-restricted to `[project.dependencies]`), and the umbrella
+  rewrites `langflow-base[complete]`→`langflow-base` + drops the 4 `lfx-*`. The lean core was
+  validated empirically (`import langflow`/pip_check); `jq` + `onnxruntime` were also demoted
+  once the build proved they're component-level, not load-time core.
+- **This dissolves the langflow→lfx-*→lfx bootstrap cycle** (the umbrella no longer hard-deps
+  `lfx-*`), so the earlier Q1 split-vs-keep question is moot — the single 3-output recipe stands
+  and submits cleanly, versions locked in lockstep.
+- **`lfx` keeps its upstream hard deps** (it IS the executor core): `langchain` +
+  `langchain-classic` + `opendsstar` (→ `litellm`), etc. This is **why the two external cf skews
+  still gate `lfx` on conda-forge** even though langflow-base/langflow are now lean
+  (§ External skews) — the local channel works around them with rebuilt `langchain`/`litellm`.
 
 ---
 
@@ -208,6 +207,12 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 *in isolation* on cf, but the full langflow graph does not. Per the CFE Build-Failure-Protocol
 "external cf ecosystem version-skew" case — fix upstream, do not churn the consumer recipe.
 
+> **STATUS 2026-06-23:** both **core-gating** skews (1 + 2) are **worked around locally** —
+> rebuilt `langchain` 1.2.18 / `litellm` 1.89.3 (base deps) into the channel → langflow-suite is
+> GREEN. Each still needs its **durable cf feedstock PR** (below) before cf submission can succeed.
+> Skew 3 (otel cluster) is now **optional-only** — the lean re-architecture moved it to
+> `run_constraints`, so it no longer gates the core.
+
 ### Skew 1 — langchain-text-splitters (PRIMARY hard blocker; the only one blocking langflow-suite core)
 
 - **Symptom:** `lfx` test-env solve fails. `lfx` pins **both** `langchain~=1.2.0` and
@@ -232,21 +237,28 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 - **Diagnosis test:** solve `langchain` + `langchain-classic` + `langchain-text-splitters` in
   isolation on cf — confirms the conflict is feedstock-internal, not a consumer defect.
 
-### Skew 2 — litellm ↔ lfx fastapi/cryptography (full-integration path)
+### Skew 2 — litellm proxy-extras flattened as hard deps (gates the CORE suite via lfx)
 
-- `lfx 1.10.0` needs `fastapi>=0.135.0,<1.0` + `cryptography>=46.0.7`. cf `litellm` (pulled via the
-  `opendsstar`→litellm path in the `[complete]` closure) bakes `fastapi==0.124.4` (litellm 1.83–1.87)
-  or conflicting otlp/text-splitters pins (1.88+).
-- **Fix:** PR `litellm-feedstock` to widen the `fastapi` pin to admit `>=0.135`, or rebuild
-  `litellm` locally at a fastapi-compatible version. Only bites the optional integration closure,
-  not the core suite.
+- **Root cause (verified 2026-06-23):** upstream `litellm` lists `fastapi`, `cryptography`, and
+  `opentelemetry-api==1.28.0` ONLY under its `proxy` / `proxy-runtime` **extras** — the core SDK
+  needs none of them. The cf `litellm` feedstock **flattens those extras into HARD deps**. `lfx`
+  hard-pulls `litellm` (via `opendsstar`), so the baked `opentelemetry-api==1.28.0` collides with
+  langflow-base's `opentelemetry-api>=1.30`, and the proxy `fastapi` pin with lfx's
+  `fastapi>=0.135`. This gates the **core** suite (lfx is a hard dep), not just optional integrations.
+- **Done locally:** rebuilt `litellm` 1.89.3 with **base deps only** (no proxy extras) into the
+  local channel → langflow-base + langflow go GREEN. **Durable fix:** PR `conda-forge/litellm-feedstock`
+  to stop flattening the `proxy` / `proxy-runtime` extras into hard run deps (keep them optional).
+- This also **subsumes the old "otel/observability skew" for the core**: with base-only litellm
+  there is no `otel-api==1.28.0`, and lean langflow-base keeps `otel-api>=1.30`.
 
-### Skew 3 — otel / observability cluster
+### Skew 3 — otel observability cluster (OPTIONAL integrations only — no longer gates the core)
 
-- `traceloop-sdk` forces `opentelemetry-semantic-conventions ==0.57b0..0.62b0` + `langchain>=0.3.15,<0.4.0`,
-  conflicting with `arize-phoenix-otel` / `opik` / `openinference-*` and lfx's newer `langchain`.
-- **Fix:** widen the otel / `traceloop-sdk` / `openinference-*` feedstock pins (may require
-  coordinating several feedstocks). Optional-integration scope only.
+- `traceloop-sdk` / `arize-phoenix-otel` / `opik` / `openinference-*` carry mutually-incompatible
+  otel-semantic-conventions / `langchain<0.4` pins. With the **lean** re-architecture these are all
+  `run_constraints` (never force-installed), so this **no longer blocks** langflow-suite — it only
+  matters for a user who opts into that observability cluster.
+- **Fix (deferred, optional):** widen the otel / `traceloop-sdk` / `openinference-*` feedstock pins
+  if/when the cluster is made co-installable. Not a submission gate.
 
 ---
 
@@ -256,17 +268,21 @@ These are conda-forge **feedstock pin-convergence** problems: each conflicting s
 > recipe locally (against the merged local channel) before pushing. After each feedstock push,
 > request rerender.
 
-### Wave A — clear the external skews (gate to langflow-suite test-GREEN)
+### Wave A — clear the external skews (gate to langflow-suite test-GREEN) — DONE LOCALLY 2026-06-23
 
-- **A1 — langchain-text-splitters (Skew 1).** **Local rebuild FIRST** (resolved approach): rebuild
-  `langchain` locally with the loosened text-splitters pin → rebuild `lfx` → re-attempt the
-  3-output `langflow-suite` → require all 3 outputs **build + test GREEN (py3.11 leg)**. This is the
-  **only** skew blocking the core suite. THEN file + land the `conda-forge/langchain-feedstock`
-  ~1-line pin fix (the durable unblock for cf submission). Also in A1: **build + verify
-  `firecrawl-py`** (only closure recipe lacking a build record), and confirm `opendsstar` resolves
-  without `ragstack-ai-knowledge-store`. Flip affected cfe-status to `pending-submission-to-conda-forge`.
-- **A2 — litellm/fastapi (Skew 2)** and **A3 — otel cluster (Skew 3).** Needed only for the
-  optional-integration closure (Wave C). Drive in parallel; not a gate for Wave B.
+All 3 langflow-suite outputs now build + test GREEN locally (imports + pip_check). What remains in
+Wave A is the **two durable conda-forge feedstock PRs** — the local channel rebuilds are the
+iteration loop; the PRs are what actually unblock cf submission:
+
+- **A1 — langchain-text-splitters (Skew 1). Local rebuild DONE** (`langchain` 1.2.18, base deps,
+  in channel). **Durable fix to file:** ~1-line `conda-forge/langchain-feedstock` PR dropping the
+  stale `langchain-text-splitters <1.0.0` pin (verify vs the exact cf-pinned 1.2.x upstream metadata).
+- **A2 — litellm proxy-extras flatten (Skew 2). Local rebuild DONE** (`litellm` 1.89.3, base deps,
+  in channel). **Durable fix to file:** `conda-forge/litellm-feedstock` PR to stop flattening the
+  `proxy` / `proxy-runtime` extras into hard run deps.
+- **A3 — otel cluster (Skew 3):** no longer a Wave-A gate (lean → `run_constraints`); deferred/optional.
+- Carryover checks: confirm `opendsstar` resolves without `ragstack-ai-knowledge-store` (BUSL-1.1,
+  out of scope). `firecrawl-py` build record now recorded (it's a `run_constraints` integration).
 
 ### Wave B — submit the core hard-dep closure (leaves → roots)
 

--- a/recipes/langchain/recipe.yaml
+++ b/recipes/langchain/recipe.yaml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  version: "1.2.18"
+
+package:
+  name: langchain
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/l/langchain/langchain-${{ version }}.tar.gz
+  sha256: 7e829dbf117affadfd2067a0e97b4af20222f535f30fb812a28472d842c1074c
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10.0,<4.0.0
+    - hatchling
+    - pip
+  run:
+    - python >=3.10.0,<4.0.0
+    - langchain-core >=1.3.3,<2.0.0
+    - langgraph >=1.1.10,<1.2.0
+    - pydantic >=2.7.4,<3.0.0
+
+tests:
+  - python:
+      imports:
+        - langchain
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  summary: Building applications with LLMs through composability
+  description: |
+    # 🦜️🔗 LangChain
+  license: MIT
+  license_file: LICENSE
+  homepage: https://docs.langchain.com/
+  repository: https://github.com/langchain-ai/langchain
+  documentation: https://reference.langchain.com/python/langchain/langchain/
+
+extra:
+  recipe-maintainers:
+    - rxm7706
+
+#### CFE metadata AND comments
+# CFE metadata
+  cfe-conda-name: langchain
+  cfe-upstream-registry: pypi
+  cfe-upstream-name: langchain
+  cfe-import-names: [langchain]
+  cfe-source-kind: pypi-sdist
+  cfe-noarch: python
+  cfe-pip-check: true
+  cfe-on-conda-forge-status: confirmed-on-conda-forge
+  cfe-on-conda-forge-feedstock: https://github.com/conda-forge/langchain-feedstock
+  cfe-forge-recipe-updates-needed:
+    - drop-stale-langchain-text-splitters-pin
+  cfe-last-checked: 2026-06-23T11:19:47Z
+  cfe-local-build-status: success
+  cfe-local-build-datetime: 2026-06-23T11:19:47Z
+  cfe-local-build-platform: linux-64
+  cfe-local-build-tool: rattler-build
+####
+# CFE comments
+# Header:
+#    # LOCAL-ONLY SKEW WORKAROUND — do NOT submit (langchain is already on
+#    # conda-forge). This local build exists only to unblock the langflow-suite
+#    # local test-env solve (Skew 1). It uses the REAL upstream 1.2.18 deps
+#    # (langchain-core / langgraph / pydantic) and therefore DROPS the cf
+#    # langchain-feedstock's STALE `langchain-text-splitters <1.0.0` pin —
+#    # absent from upstream 1.2.x, it conflicts with langchain-classic +
+#    # opendsstar (both need text-splitters >=1.1.0). Durable fix = a
+#    # langchain-feedstock PR dropping the stale pin (spec Wave A1); then this
+#    # local recipe can be deleted.
+####

--- a/recipes/langflow-suite/recipe.yaml
+++ b/recipes/langflow-suite/recipe.yaml
@@ -98,7 +98,7 @@ outputs:
         - |
           # Strip optional-integration deps from the wheel METADATA so langflow-base
           # stays lean (no langflow[full]); they are listed in run_constraints below.
-          sed -i -E '/^dependencies = \[/,/^\]/{/(langchain-mongodb|langchain-perplexity|langchain-qdrant|langchain-weaviate|langchain-chroma|langchain-ibm|ibm-watsonx-ai|firecrawl-py|spider-client|assemblyai|elevenlabs|clickhouse-connect|duckdb|trustcall|jq|onnxruntime)[<>=~]/d}' src/backend/base/pyproject.toml
+          sed -i.bak -E '/^dependencies = \[/,/^\]/{/(langchain-mongodb|langchain-perplexity|langchain-qdrant|langchain-weaviate|langchain-chroma|langchain-ibm|ibm-watsonx-ai|firecrawl-py|spider-client|assemblyai|elevenlabs|clickhouse-connect|duckdb|trustcall|jq|onnxruntime)[<>=~]/d}' src/backend/base/pyproject.toml && rm src/backend/base/pyproject.toml.bak
         - ${{ PYTHON }} -m pip install src/backend/base -vv --no-deps --no-build-isolation
     requirements:
       host:
@@ -143,7 +143,6 @@ outputs:
         - pandas >=2.2.3
         - multiprocess >=0.70.14,<1.0.0
         - python-docx >=1.1.0,<2.0.0
-        - jq >=1.7.0,<2.0.0
         - nest-asyncio >=1.6.0,<2.0.0
         - emoji >=2.12.0,<3.0.0
         - cryptography >=46.0.7
@@ -180,7 +179,6 @@ outputs:
         - scipy >=1.15.2,<2.0.0
         - jaraco.context >=6.1.0
         - wheel >=0.46.2,<1.0.0
-        - onnxruntime >=1.20
         - dynaconf >=3.2.13,<4.0.0
         - pyasn1 >=0.6.3,<0.7.0
         - langgraph-checkpoint >4.0.0,<5.0.0
@@ -224,7 +222,7 @@ outputs:
         - |
           # Lean umbrella: depend only on langflow-base (not [complete]); the lfx-*
           # component packs + all integrations are optional (run_constraints), not forced.
-          sed -i -E '/^dependencies = \[/,/^\]/{s/langflow-base\[complete\]/langflow-base/; /"(lfx-duckduckgo|lfx-arxiv|lfx-ibm|lfx-docling)>/d}' pyproject.toml
+          sed -i.bak -E '/^dependencies = \[/,/^\]/{s/langflow-base\[complete\]/langflow-base/; /"(lfx-duckduckgo|lfx-arxiv|lfx-ibm|lfx-docling)>/d}' pyproject.toml && rm pyproject.toml.bak
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:

--- a/recipes/langflow-suite/recipe.yaml
+++ b/recipes/langflow-suite/recipe.yaml
@@ -95,6 +95,10 @@ outputs:
     build:
       noarch: python
       script:
+        - |
+          # Strip optional-integration deps from the wheel METADATA so langflow-base
+          # stays lean (no langflow[full]); they are listed in run_constraints below.
+          sed -i -E '/^dependencies = \[/,/^\]/{/(langchain-mongodb|langchain-perplexity|langchain-qdrant|langchain-weaviate|langchain-chroma|langchain-ibm|ibm-watsonx-ai|firecrawl-py|spider-client|assemblyai|elevenlabs|clickhouse-connect|duckdb|trustcall|jq|onnxruntime)[<>=~]/d}' src/backend/base/pyproject.toml
         - ${{ PYTHON }} -m pip install src/backend/base -vv --no-deps --no-build-isolation
     requirements:
       host:
@@ -104,55 +108,102 @@ outputs:
       run:
         - python >=${{ python_min }},<3.15
         - ${{ pin_subpackage('lfx', exact=True) }}
-        # Core Underlying Framework Dependencies
-        - langchain >=1.2.0,<1.3.0
-        - langchain-core
-        - langchain-community
-        - pydantic
-        - fastapi
-        - fastapi-pagination
-        - uvicorn
-        - gunicorn
-        - alembic
-        - sqlmodel
-        - sqlalchemy
-        - greenlet
-        - cachetools
-        - loguru
-        - rich
-        - typer
-        - httpx
+        # Flattened from upstream src/backend/base/pyproject.toml
+        # [project.dependencies] (G25: conda has no extras; G24: caps mirrored).
+        - fastapi >=0.135.0,<1.0.0
+        - slowapi >=0.1.9,<1.0.0
+        - httpx >=0.27,<1.0.0
         - h2
-        - orjson
-        - numpy
-        - pandas
-        - scipy
-        - transformers
-        - onnxruntime
-        - pillow
-        - filelock
-        - multiprocess
-        - networkx
-        - pyarrow
-        - cryptography
-        - bcrypt
-        - pyjwt
-        - passlib
-        - nest-asyncio
-        - platformdirs
-        - python-multipart
-        - chardet
-        - validators
-        - email-validator
-        - jinja2
-        - markupsafe
-        - markdown
-        - beautifulsoup4
-        - defusedxml
-        - slowapi
-        - prometheus-client
-        - opentelemetry-api
-        - opentelemetry-sdk
+        - aiofile >=3.9.0,<4.0.0
+        - uvicorn >=0.30.0,<1.0.0
+        - gunicorn >=25.3.0,<27.0.0
+        - langchain >=1.2.0,<1.3.0
+        - langchain-community >=0.4.1,<0.5.0
+        - langchain-core >=1.3.3,<2.0.0
+        - langchainhub >=0.1.15,<0.2.0
+        - loguru >=0.7.1,<1.0.0
+        - structlog >=25.4.0,<26.0.0
+        - rich >=13.7.0,<14.0.0
+        - langchain-experimental >=0.4.1,<0.5.0
+        - sqlmodel >=0.0.37,<0.1.0
+        - pydantic >=2.13.0,<3.0.0
+        - pydantic-settings >=2.2.0,<3.0.0
+        - email-validator >=2.0.0
+        - typer >=0.13.0,<1.0.0
+        - cachetools >=6.0.0
+        - platformdirs >=4.2.0,<5.0.0
+        - python-multipart >=0.0.12,<1.0.0
+        - orjson >=3.11.6,<4.0.0
+        - alembic >=1.13.0,<2.0.0
+        - passlib >=1.7.4,<2.0.0
+        - bcrypt ==4.0.1
+        - pillow >=12.1.1,<13.0.0
+        - docstring_parser >=0.16,<1.0.0
+        - pyjwt >=2.12.1
+        - pandas >=2.2.3
+        - multiprocess >=0.70.14,<1.0.0
+        - python-docx >=1.1.0,<2.0.0
+        - jq >=1.7.0,<2.0.0
+        - nest-asyncio >=1.6.0,<2.0.0
+        - emoji >=2.12.0,<3.0.0
+        - cryptography >=46.0.7
+        - asyncer >=0.0.5,<1.0.0
+        - pyperclip >=1.8.2,<2.0.0
+        - uncurl >=0.0.11,<1.0.0
+        - sentry-sdk >=2.5.1,<3.0.0
+        - chardet >=7.3.0
+        - opentelemetry-api >=1.30.0,<2.0.0
+        - opentelemetry-sdk >=1.30.0,<2.0.0
+        - opentelemetry-exporter-prometheus >=0.50b0,<1.0.0
+        - opentelemetry-exporter-otlp >=1.30.0,<2.0.0
+        - opentelemetry-instrumentation-fastapi >=0.50b0,<1.0.0
+        - opentelemetry-instrumentation-requests >=0.50b0,<1.0.0
+        - opentelemetry-instrumentation-urllib3 >=0.50b0,<1.0.0
+        - prometheus_client >=0.20.0,<1.0.0
+        - aiofiles >=24.1.0,<25.0.0
+        - pip >=26.0.0,<27.0.0
+        - setuptools >=80.0.0,<81.0.0
+        - nanoid >=2.0.0,<3.0.0
+        - filelock >=3.20.1,<4.0.0
+        - grandalf >=0.8.0,<1.0.0
+        - fastapi-pagination >=0.13.1,<1.0.0
+        - defusedxml >=0.7.1,<1.0.0
+        - pypdf >=6.10.0,<7.0.0
+        - validators >=0.34.0,<1.0.0
+        - networkx >=3.4.2,<4.0.0
+        - json-repair >=0.30.3,<1.0.0
+        - mcp >=1.17.0,<2.0.0
+        - aiosqlite >=0.20.0,<1.0.0
+        - greenlet >=3.1.1,<4.0.0
+        - jsonquerylang >=1.1.1,<2.0.0
+        - sqlalchemy >=2.0.38,<3.0.0
+        - scipy >=1.15.2,<2.0.0
+        - jaraco.context >=6.1.0
+        - wheel >=0.46.2,<1.0.0
+        - onnxruntime >=1.20
+        - dynaconf >=3.2.13,<4.0.0
+        - pyasn1 >=0.6.3,<0.7.0
+        - langgraph-checkpoint >4.0.0,<5.0.0
+      run_constraints:
+        # Optional integrations (upstream langflow-base extras) — stripped from the
+        # wheel METADATA at build (lean base, no langflow[full]); version-pinned so
+        # they are constrained IF a user installs them, never forced.
+        - langchain-mongodb >=0.11.0
+        - langchain-perplexity >=1.0.0,<2.0.0
+        - langchain-qdrant >=1.0.0,<2.0.0
+        - langchain-weaviate >=0.0.6
+        - langchain-chroma >=0.2.6,<0.3.0
+        - langchain-ibm >=1.1.0,<1.2.0
+        - ibm-watsonx-ai >=1.3.1,<2.0.0
+        - firecrawl-py >=1.0.16,<2.0.0
+        - spider-client >=0.0.27,<1.0.0
+        - assemblyai >=0.33.0,<1.0.0
+        - elevenlabs >=1.52.0,<2.0.0
+        - clickhouse-connect ==0.7.19
+        - duckdb >=1.0.0,<2.0.0
+        - trustcall >=0.0.38,<1.0.0
+        - jq >=1.7.0,<2.0.0
+        - onnxruntime >=1.20
     tests:
       - python:
           imports:
@@ -170,6 +221,10 @@ outputs:
     build:
       noarch: python
       script:
+        - |
+          # Lean umbrella: depend only on langflow-base (not [complete]); the lfx-*
+          # component packs + all integrations are optional (run_constraints), not forced.
+          sed -i -E '/^dependencies = \[/,/^\]/{s/langflow-base\[complete\]/langflow-base/; /"(lfx-duckduckgo|lfx-arxiv|lfx-ibm|lfx-docling)>/d}' pyproject.toml
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:
@@ -178,19 +233,15 @@ outputs:
         - hatchling
       run:
         - python >=${{ python_min }},<3.15
+        # Upstream langflow = langflow-base[complete] + 4 lfx-* extension packs.
+        # Lean: hard-dep only langflow-base (it provides the importable `langflow`);
+        # the lfx-* packs + all integrations are optional (run_constraints below).
         - ${{ pin_subpackage('langflow-base', exact=True) }}
-        - jsonquerylang >=1.1.1,<2.0.0  # cf-W1 HARD prereq, recipe ready
-        - mcp
-        - fastmcp
-        - atlaspy  # NOT an upstream langflow dep (v1.10.0) - remove
-        - dynamicconf  # NOT an upstream langflow dep (v1.10.0) - remove
-        - grandalf
-        - lark
-        - nanoid
-        - uncurl
-        - sseclient-py
-        - structlog
       run_constraints:
+        # langflow's own optional component deps (upstream extras), demoted from run:
+        - fastmcp
+        - lark
+        - sseclient-py
         # 1. Internal Comps/Component Packs (Isolated to prevent staging locks)
         - lfx-arxiv >=0.1  # cf-W2 optional, recipe ready
         - lfx-docling >=0.1  # cf-W2 optional, recipe ready
@@ -313,50 +364,39 @@ extra:
   cfe-on-conda-forge-feedstock: none
   cfe-forge-recipe-updates-needed: none
   cfe-forge-blocker-list:
-    # 2026-06-19 re-build: ALL previously-named missing third-party deps now
-    # RESOLVE (authored + in local channel). The recipe BUILDS; both legs are
-    # TEST-solve-blocked by TWO external conda-forge ecosystem version-skew
-    # conflicts (NOT locally fixable — require upstream feedstock pin
-    # convergence or upstream langflow-base constraint relaxation):
+    # 2026-06-23 STATUS: ALL 3 outputs (lfx, langflow-base, langflow) BUILD +
+    # TEST GREEN locally (imports + pip_check) against the local channel. Two
+    # things made this work:
+    #  (A) LEAN re-architecture (rxm7706 directive): langflow-base + langflow
+    #      hard-dep only the framework core; ALL integrations (langchain
+    #      providers, vector/analytics DB clients, external SDKs, the 4 lfx-*
+    #      component packs) are run_constraints, and those integration deps are
+    #      sed-stripped from the wheel METADATA at build so pip_check stays
+    #      lean + green. No more langflow[full] forced on every user.
+    #  (B) Local skew-workaround channel builds for the two cf feedstock pins
+    #      that block lfx's HARD deps (lfx -> langchain + langchain-classic, and
+    #      lfx -> opendsstar -> litellm). These two remain the DURABLE
+    #      conda-forge submission prerequisites:
     #
-    # 1. litellm <-> lfx fastapi/cryptography/langchain-text-splitters skew:
-    #    lfx requires fastapi>=0.135.0,<1.0 + cryptography>=46.0.7, but every
-    #    conda-forge litellm build (pulled via opendsstar>=1.83.0) bakes in
-    #    fastapi==0.124.4 (1.83-1.87) or otlp/langchain-text-splitters pins
-    #    that conflict with lfx's langchain stack. The pins live in the cf
-    #    litellm / langchain-text-splitters feedstock wheel METADATA.
-    # 2. observability-cluster opentelemetry-semantic-conventions / -api skew:
-    #    traceloop-sdk needs otel-instrumentation-logging>=0.57b0 (forcing
-    #    semantic-conventions==0.57b0..0.62b0) + langchain>=0.3.15,<0.4.0,
-    #    which conflict with arize-phoenix-otel / opik / openinference-* and
-    #    with lfx's newer langchain. All on conda-forge.
-    #
-    # LOCAL FIXES APPLIED THIS SESSION (recipe corrections, all built green):
-    #  - docstring-parser -> docstring_parser (G10 underscore feedstock name;
-    #    fixed here AND in langflow-base, whose artifact baked the bad hyphen).
-    #  - python_min raised to 3.11: jsonquerylang (every version) imports
-    #    typing.NotRequired unconditionally (PEP 655, py3.11+), and
-    #    ibm-watsonx-orchestrate-* are py3.11-gated -> 3.11 is the honest floor
-    #    despite upstream's aspirational requires-python >=3.10.
-    #  - jsonquerylang pinned >=1.1.1,<2.0.0 (mirror upstream langflow-base
-    #    pin; load-bearing under pip_check, G24/G26). jsonquerylang 1.1.1
-    #    built into the local channel (channel had only 2.1.0, which violates
-    #    the <2.0.0 upstream cap).
-    - litellm/fastapi/cryptography ecosystem skew (external cf)
-    - opentelemetry-semantic-conventions/api observability skew (external cf)
-    # 2026-06-23 lfx test-env solve: irreducible langchain-text-splitters skew.
-    # cf `langchain 1.2.x` (lfx pins langchain~=1.2.0) requires
-    # langchain-text-splitters <1.0.0 AND is built py>=3.13 only, while
-    # `langchain-classic ~=1.0.7` and local `opendsstar ==1.0.26` require
-    # langchain-text-splitters >=1.1.0 — mutually unsatisfiable. Fix is upstream
-    # cf pin convergence (langchain feedstock loosening text-splitters), not a
-    # langflow-suite edit. All 3 outputs BUILD clean (--test skip green).
-    - langchain/langchain-classic/langchain-text-splitters skew (external cf)
-  cfe-last-checked: 2026-06-23T09:13:56Z
+    #   1. cf `langchain` feedstock carries a STALE `langchain-text-splitters
+    #      <1.0.0` pin — absent from upstream langchain 1.2.x (which deps only
+    #      langchain-core/langgraph/pydantic) — that conflicts with
+    #      langchain-classic + opendsstar (both need >=1.1.0). Worked around with
+    #      a local langchain 1.2.18 (base deps). Durable fix: langchain-feedstock
+    #      PR dropping the stale text-splitters pin.
+    #   2. cf `litellm` feedstock flattens the proxy / proxy-runtime EXTRAS
+    #      (fastapi, cryptography, opentelemetry-api==1.28.0) into HARD deps;
+    #      upstream lists them ONLY under extras. otel-api==1.28.0 then conflicts
+    #      with langflow-base's otel-api>=1.30 and the fastapi pin with lfx's
+    #      fastapi>=0.135. Worked around with a local litellm 1.89.3 (base deps
+    #      only). Durable fix: litellm-feedstock not flattening proxy extras.
+    - cf langchain-feedstock - drop stale langchain-text-splitters <1.0.0 pin
+    - cf litellm-feedstock - do not flatten proxy/proxy-runtime extras as hard deps
+  cfe-last-checked: 2026-06-23T15:48:01Z
   cfe-generated-by-version: 8.34.0
   cfe-generated-at-datetime: 2026-06-19T13:36:19Z
-  cfe-local-build-status: build-clean-test-blocked
-  cfe-local-build-datetime: 2026-06-23T09:13:56Z
+  cfe-local-build-status: success
+  cfe-local-build-datetime: 2026-06-23T15:48:01Z
   cfe-local-build-platform: linux-64
   cfe-local-build-tool: rattler-build
 ####

--- a/recipes/litellm/recipe.yaml
+++ b/recipes/litellm/recipe.yaml
@@ -2,9 +2,7 @@
 schema_version: 1
 
 context:
-  version: "1.83.14"
-  python_max: '3.14'
-  python_test_max: '3.13'
+  version: "1.89.3"
 
 package:
   name: litellm
@@ -12,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/l/litellm/litellm-${{ version }}.tar.gz
-  sha256: 24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9
+  sha256: 8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510
 
 build:
   number: 0
@@ -25,86 +23,23 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}.*
-    - uv-build >=0.10.7 # Loosen pin ==0.10.7
+    - python >=3.10,<3.14
+    - uv-build >=0.11.8,<0.12
     - pip
   run:
-    - python >=${{ python_min }},<${{ python_max }}
-    - fastuuid ==0.14.0
-    - httpx ==0.28.1
-    - openai ==2.24.0
-    - python-dotenv ==1.2.2
-    - tiktoken ==0.12.0
-    - importlib-metadata ==8.5.0
-    - tokenizers ==0.22.2
-    - click ==8.1.8
-    - jinja2 ==3.1.6
-    - aiohttp ==3.13.4
-    - pydantic ==2.12.5
-    - jsonschema ==4.23.0
-  run_constraints:
-    # Versions loosened from upstream's PyPI exact-pin extras
-    # (litellm[proxy], litellm[caching], litellm[extra-proxy]) to `>=`
-    # bounds so the conda-forge ecosystem can advance dependencies without
-    # re-cutting litellm. The lower bound documents the minimum litellm
-    # itself was tested against; conda-forge typically ships newer.
-    - uvicorn >=0.33.0
-    - uvloop >=0.21.0
-    - gunicorn >=23.0.0
-    - fastapi >=0.124.4
-    - backoff >=2.2.1
-    - pyyaml >=6.0.3
-    - rq >=2.4.0 # loosen pin rq >=2.7.0
-    - orjson >=3.11.6
-    - apscheduler >=3.11.2
-    - pyjwt >=2.12.0
-    - python-multipart >=0.0.26
-    - cryptography >=46.0.7
-    - azure-identity >=1.25.2
-    - azure-keyvault-secrets >=4.10.0
-    - azure-storage-blob >=12.28.0
-    - google-cloud-kms >=2.24.2
-    - google-cloud-iam >=2.19.1
-    - google-cloud-aiplatform >=1.133.0
-    - pynacl >=1.6.2
-    - websockets >=15.0.1
-    - boto3 >=1.42.59
-    - mcp >=1.26.0
-    - a2a-sdk >=0.3.24
-    - rich >=13.9.4
-    - diskcache >=5.6.3
-    - polars >=1.38.1
-    - mlflow >=3.11.1
-    - fastapi-sso >=0.19.0
-    - redisvl >=0.4.1
-    - pyroscope-io >=0.8.16
-    - grpcio >=1.78.0
-    - restrictedpython >=8.1
-    # Not (yet) available on conda-forge — kept here as commented
-    # constrains so the version intent is preserved for when each is
-    # packaged. Uncomment as the conda-forge ecosystem catches up.
-    #
-    #   prisma                — litellm[extra-proxy] DB schema management
-    #   resend                — litellm[extra-proxy] transactional email
-    #   semantic-router       — litellm[extra-proxy] semantic-cache layer
-    #   aurelio-sdk           — transitive dep of semantic-router
-    #   litellm-proxy-extras  — sibling package, recipe pending submission
-    #   litellm-enterprise    — proprietary licence (LicenseRef-Proprietary);
-    #                           conda-forge does not redistribute proprietary code
-    #
-    # - prisma >=0.11.0
-    # - resend >=2.23.0
-    # - semantic-router >=0.1.12
-    # - aurelio-sdk >=0.0.19
-    # - litellm-proxy-extras >=0.4.69
-    # - litellm-enterprise >=0.1.39
-    #
-    # `soundfile` is the PyPI name; conda-forge publishes the same
-    # library as `pysoundfile`. The constrain is omitted because pinning
-    # `soundfile` on conda-forge has no effect (no candidates to filter)
-    # and pinning `pysoundfile` would diverge from the upstream PyPI
-    # extras-metadata declaration.
-    # - soundfile >=0.12.1
+    - python >=3.10,<3.14
+    - fastuuid >=0.14.0,<1.0
+    - httpx >=0.28.0,<1.0
+    - openai >=2.20.0,<3.0.0
+    - python-dotenv >=1.0.0,<2.0
+    - tiktoken >=0.8.0,<1.0
+    - importlib-metadata >=8.0.0,<9.0
+    - tokenizers >=0.21.0,<1.0
+    - click >=8.0.0,<9.0
+    - jinja2 >=3.1.6,<4.0
+    - aiohttp >=3.10,<4.0
+    - pydantic >=2.10.0,<3.0.0
+    - jsonschema >=4.0.0,<5.0
 
 tests:
   - python:
@@ -113,25 +48,65 @@ tests:
       pip_check: true
       python_version:
         - ${{ python_min }}.*
-        - ${{ python_test_max }}.*
+        - "*"
   - requirements:
       run:
         - pip
         - python ${{ python_min }}.*
     script:
       - litellm --help
-      #- litellm-proxy --help
+      - litellm-proxy --help
 
 about:
   summary: Library to easily interface with LLM API providers
+  description: |
+    <h1 align="center">
+            🚅 LiteLLM
+        </h1>
+        <p align="center">
+            <p align="center">LiteLLM AI Gateway
+            </p>
+            <p align="center">Open Source AI Gateway for 100+ LLMs. Self-hosted. Enterprise-ready. Call any LLM in OpenAI format.</p>
+            <p align="center">
+            <a href="https://render.com/deploy?repo=https://github.com/BerriAI/litellm" target="_blank" rel="nofollow"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render"></a>...
   license: MIT
   license_file: LICENSE
   homepage: https://litellm.ai
-  documentation: https://docs.litellm.ai
   repository: https://github.com/BerriAI/litellm
+  documentation: https://docs.litellm.ai
 
 extra:
   recipe-maintainers:
-    - m-rossi
-    - jan-janssen
     - rxm7706
+
+#### CFE metadata AND comments
+# CFE metadata
+  cfe-conda-name: litellm
+  cfe-upstream-registry: pypi
+  cfe-upstream-name: litellm
+  cfe-import-names: [litellm]
+  cfe-source-kind: pypi-sdist
+  cfe-noarch: python
+  cfe-pip-check: true
+  cfe-on-conda-forge-status: confirmed-on-conda-forge
+  cfe-on-conda-forge-feedstock: https://github.com/conda-forge/litellm-feedstock
+  cfe-forge-recipe-updates-needed:
+    - do-not-flatten-proxy-and-proxy-runtime-extras-as-hard-deps
+  cfe-last-checked: 2026-06-23T15:48:01Z
+  cfe-local-build-status: success
+  cfe-local-build-datetime: 2026-06-23T15:48:01Z
+  cfe-local-build-platform: linux-64
+  cfe-local-build-tool: rattler-build
+####
+# CFE comments
+# Header:
+#    # LOCAL-ONLY SKEW WORKAROUND — do NOT submit (litellm is already on
+#    # conda-forge). This local build exists only to unblock the langflow-suite
+#    # local test-env solve (Skew 2/3). It uses the REAL upstream 1.89.3 BASE
+#    # deps and therefore OMITS the proxy / proxy-runtime EXTRAS (fastapi,
+#    # cryptography, opentelemetry-api==1.28.0) that the cf litellm-feedstock
+#    # flattens into HARD deps. Those extras' otel-api==1.28.0 conflicts with
+#    # langflow-base's otel-api>=1.30, and the fastapi pin with lfx's
+#    # fastapi>=0.135. Durable fix = litellm-feedstock not flattening the proxy
+#    # extras; then this local recipe can be deleted.
+####

--- a/recipes/litellm/recipe.yaml
+++ b/recipes/litellm/recipe.yaml
@@ -49,13 +49,10 @@ tests:
       python_version:
         - ${{ python_min }}.*
         - "*"
-  - requirements:
-      run:
-        - pip
-        - python ${{ python_min }}.*
-    script:
-      - litellm --help
-      - litellm-proxy --help
+  # NOTE: the `litellm` / `litellm-proxy` CLI tests are intentionally omitted —
+  # this LOCAL-ONLY build strips the proxy / proxy-runtime extras (fastapi, etc.),
+  # so the proxy CLIs are non-functional here. The import test above covers the
+  # library (the only surface this skew-workaround build provides).
 
 about:
   summary: Library to easily interface with LLM API providers

--- a/recipes/milvus-lite/recipe.yaml
+++ b/recipes/milvus-lite/recipe.yaml
@@ -18,7 +18,7 @@ build:
   script: |
     # conda faiss-cpu exposes bindings under dist-info `faiss` (no `faiss-cpu`
     # dist-info); rewrite the wheel METADATA dep so `pip check` sees `faiss` (G28).
-    sed -i 's/"faiss-cpu>=1.7.4"/"faiss>=1.7.4"/' pyproject.toml
+    sed -i.bak 's/"faiss-cpu>=1.7.4"/"faiss>=1.7.4"/' pyproject.toml && rm pyproject.toml.bak
     ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:

--- a/recipes/milvus-lite/recipe.yaml
+++ b/recipes/milvus-lite/recipe.yaml
@@ -15,7 +15,11 @@ source:
 build:
   noarch: python
   number: 0
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: |
+    # conda faiss-cpu exposes bindings under dist-info `faiss` (no `faiss-cpu`
+    # dist-info); rewrite the wheel METADATA dep so `pip check` sees `faiss` (G28).
+    sed -i 's/"faiss-cpu>=1.7.4"/"faiss>=1.7.4"/' pyproject.toml
+    ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:
       - milvus-lite = milvus_lite.cmdline:main
@@ -34,16 +38,13 @@ requirements:
     - tomli >=2.0
 
 tests:
-  # pip_check disabled (G28 external false positive): upstream wheel METADATA
-  # declares `faiss-cpu>=1.7.4` (PyPI dist name) but conda-forge ships the
-  # importable bindings under dist-info `faiss` (conda `faiss-cpu` is a thin
-  # metapackage with no pip-visible faiss-cpu dist-info). `pip check` reports
-  # "requires faiss-cpu, which is not installed" though `import faiss` works.
-  # Verified faiss-cpu is the ONLY pip-check line; not a recipe defect.
+  # pip_check re-enabled: the build rewrites the wheel METADATA dep
+  # `faiss-cpu` -> `faiss` (conda faiss-cpu ships the `faiss` dist-info; there is
+  # no `faiss-cpu` dist-info), so `pip check` is satisfied by installed faiss (G28).
   - python:
       imports:
         - milvus_lite
-      pip_check: false
+      pip_check: true
       python_version:
         - ${{ python_min }}.*
         - "*"

--- a/recipes/opendsstar/recipe.yaml
+++ b/recipes/opendsstar/recipe.yaml
@@ -16,7 +16,12 @@ source:
 build:
   noarch: python
   number: 0
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: |
+    # conda `docling` is a metapackage; the importable `docling` module + its
+    # dist-info ship as `docling-slim`. Rewrite the wheel METADATA dep so
+    # `pip check` sees `docling-slim`; the conda run dep stays `docling` (G28).
+    sed -i 's/"docling>=2.36.1,<3.0.0"/"docling-slim>=2.36.1,<3.0.0"/' pyproject.toml
+    ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipes/opendsstar/recipe.yaml
+++ b/recipes/opendsstar/recipe.yaml
@@ -20,7 +20,7 @@ build:
     # conda `docling` is a metapackage; the importable `docling` module + its
     # dist-info ship as `docling-slim`. Rewrite the wheel METADATA dep so
     # `pip check` sees `docling-slim`; the conda run dep stays `docling` (G28).
-    sed -i 's/"docling>=2.36.1,<3.0.0"/"docling-slim>=2.36.1,<3.0.0"/' pyproject.toml
+    sed -i.bak 's/"docling>=2.36.1,<3.0.0"/"docling-slim>=2.36.1,<3.0.0"/' pyproject.toml && rm pyproject.toml.bak
     ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
All 3 `langflow-suite` outputs (`lfx`, `langflow-base`, `langflow`) build + test **GREEN** locally (imports + pip_check, linux-64, 2026-06-23).

## Lean re-architecture (no `langflow[full]`)
Upstream `langflow-base[complete]` forces ~90 integrations on every user. Instead:
- `langflow-base` + `langflow` hard-`run` only the **framework core**; all integrations (langchain providers, vector/analytics DB clients, external SDKs, the 4 `lfx-*` packs) → `run_constraints` (optional, version-pinned).
- Each output's build `sed`-strips the integration deps from the wheel METADATA (range-restricted to `[project.dependencies]`) so `pip_check: true` stays lean + green; the umbrella rewrites `langflow-base[complete]`→`langflow-base` and drops the 4 `lfx-*`.
- This **dissolves the `langflow`→`lfx-*`→`lfx` bootstrap cycle** — single 3-output recipe submits cleanly.

## Skew fixes
- **G28 dist-name false positives** (source-patched): `milvus-lite` `faiss-cpu`→`faiss`, `opendsstar` `docling`→`docling-slim`; `milvus-lite` `pip_check` re-enabled.
- **Local skew-workaround channel builds (`recipes/langchain`, `recipes/litellm` — LOCAL-ONLY, do NOT submit):** `langchain 1.2.18` + `litellm 1.89.3` (base deps), dropping cf's stale `langchain-text-splitters<1.0.0` pin / `litellm` proxy-runtime extras flatten.

## conda-forge submission status
`cfe-local-build-status: success`; `cfe-on-conda-forge-status: blocked-pending-prerequisites` on **2 durable feedstock fixes** (gate `lfx`'s hard deps; local channel works around both):
1. `langchain-feedstock` — drop the stale `langchain-text-splitters <1.0.0` pin
2. `litellm-feedstock` — stop flattening `proxy`/`proxy-runtime` extras as hard deps

`docs/specs/langflow-conda-forge.md` updated to match (drift-check green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)