### PR TITLE
Add add-handoff CLI: S6 ADD-bucket packaging worklist generator

### DIFF
--- a/.claude/scripts/conda-forge-expert/add_handoff.py
+++ b/.claude/scripts/conda-forge-expert/add_handoff.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""
+Entrypoint wrapper for conda-forge-expert → add_handoff.py
+Stable public CLI surface for pixi tasks and external callers.
+Canonical implementation: .claude/skills/conda-forge-expert/scripts/add_handoff.py
+Do NOT put logic here — delegate entirely to the canonical script.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+_SKILL_SCRIPT = (
+    Path(__file__).parent.parent.parent
+    / "skills" / "conda-forge-expert" / "scripts" / "add_handoff.py"
+)
+
+if __name__ == "__main__":
+    sys.exit(subprocess.run([sys.executable, str(_SKILL_SCRIPT)] + sys.argv[1:]).returncode)

--- a/.claude/skills/conda-forge-expert/scripts/add_handoff.py
+++ b/.claude/skills/conda-forge-expert/scripts/add_handoff.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+add-handoff — ADD-bucket packaging worklist with on-demand enrichment
+(cyclonedx-universe-inventory Wave C / S6).
+
+Consumes `inventory-match` results (inline run, or a saved `--json` file
+via --matches) and emits the ready-to-consume packaging worklist for the
+ADD bucket: name, readiness score, recommended template, blockers (e.g.
+non-OSI license), `signals_absent` per row — sorted readiness-desc.
+ADD-NONPYPI entries are appended unscored with their upstream identity
+(ecosystem purl). No recipes are generated in this story.
+
+Enrichment (bounded, BEFORE scoring): readiness/license coverage in
+`pypi_intelligence` is sparse, so ADD names lacking `json_fetched_at` get
+a Phase-R-style single-package `pypi.org/pypi/<name>/json` fetch — capped
+at the inventory slice (--limit caps harder; dropped names are REPORTED,
+never silently truncated), written back idempotently through the SAME
+upsert Phase R uses (`conda_forge_atlas.phase_r_upsert_one` — the effort's
+write-path discipline), then re-scored with the canonical Phase S formula
+scoped to the slice (`apply_readiness_scores(conn, names)`).
+
+FAIL-CLOSED license rule (spec S6): a NULL `license_spdx` NEVER silently
+passes the OSI-eligibility check — it is the `license-unknown` blocker.
+--no-enrich (offline mode) therefore leaves un-enriched rows BLOCKED, not
+clean.
+
+Freshness contract (decision 6): refuses an atlas older than 14 days or
+with no parseable built_at (--allow-stale overrides).
+
+CLI:
+  add-handoff [INPUT ...] [--matches RESULT.json] [--format FMT]
+              [--no-enrich] [--limit N]
+              [--report PATH] [--json] [--allow-stale]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from conda_forge_atlas import (
+    _OSI_APPROVED_SPDX,
+    apply_readiness_scores,
+    phase_r_upsert_one,
+)
+from universe_sbom import StaleAtlasError, check_freshness
+
+
+def _get_data_dir() -> Path:
+    return Path(__file__).resolve().parent.parent.parent.parent / "data" / "conda-forge-expert"
+
+
+DB_PATH = _get_data_dir() / "cf_atlas.db"
+DEFAULT_REPORT_PATH = _get_data_dir() / "add-handoff-worklist.md"
+
+# Fetcher signature — matches conda_forge_atlas._phase_r_fetch_one.
+Fetcher = Callable[[str], tuple[str, dict | None, str | None]]
+
+
+def _default_fetcher() -> Fetcher:
+    """The real Phase R fetch worker (retries, Retry-After, jitter).
+    Resolved lazily so fixture tests never touch the network path."""
+    from conda_forge_atlas import _phase_r_fetch_one
+    return _phase_r_fetch_one
+
+
+# ── enrichment (the S6 write path) ──────────────────────────────────────────
+
+def enrich_add_rows(
+    conn: sqlite3.Connection,
+    names: list[str],
+    fetcher: Fetcher,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Bounded single-package enrichment for ADD names whose
+    `pypi_intelligence` row lacks `json_fetched_at`. Idempotent by
+    construction: already-enriched names are skipped up front, and the
+    upsert is Phase R's own. Returns counters + the enriched name list."""
+    needing: list[str] = []
+    for name in names:
+        # scope: eligibility probe, not version truth — mirrors Phase R's
+        # own TTL query; NULL/missing json_fetched_at is exactly the signal.
+        row = conn.execute(
+            "SELECT json_fetched_at FROM pypi_intelligence WHERE pypi_name = ?",
+            (name,),
+        ).fetchone()
+        if row is None or row[0] is None:
+            needing.append(name)
+
+    dropped: list[str] = []
+    if limit is not None and len(needing) > limit:
+        needing, dropped = needing[:limit], needing[limit:]
+
+    now = int(time.time())
+    fetched = failed = not_found = 0
+    enriched_names: list[str] = []
+    for name in needing:
+        _, payload, err = fetcher(name)
+        outcome = phase_r_upsert_one(conn, name, payload, err, now)
+        if outcome == "fetched":
+            fetched += 1
+            enriched_names.append(name)
+        elif outcome == "not_found":
+            not_found += 1
+            enriched_names.append(name)  # 404 IS an answer (project gone)
+        else:
+            failed += 1
+    conn.commit()
+    if enriched_names:
+        apply_readiness_scores(conn, enriched_names)
+    return {
+        "eligible": len(needing) + len(dropped),
+        "fetched": fetched,
+        "not_found": not_found,
+        "failed": failed,
+        "dropped_by_limit": dropped,
+        "enriched_names": enriched_names,
+    }
+
+
+# ── worklist build ───────────────────────────────────────────────────────────
+
+_INTEL_COLS = ("pypi_name", "latest_version", "latest_yanked", "license_spdx",
+               "license_raw", "conda_forge_readiness", "recommended_template",
+               "staged_recipes_pr_url", "has_sdist", "packaging_shape",
+               "requires_python", "summary", "repo_url", "json_fetched_at",
+               "json_last_error")
+
+
+def _intel_for(conn: sqlite3.Connection, names: list[str]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for i in range(0, len(names), 500):
+        chunk = names[i:i + 500]
+        marks = ",".join("?" for _ in chunk)
+        for row in conn.execute(
+            f"SELECT {', '.join(_INTEL_COLS)} FROM v_pypi_intelligence_valid "
+            f"WHERE pypi_name IN ({marks})", chunk,
+        ):
+            out[row[0]] = dict(zip(_INTEL_COLS, row))
+    return out
+
+
+def build_worklist(
+    conn: sqlite3.Connection, add_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """One worklist entry per ADD row, blockers fail-closed on license."""
+    names = [r.get("pypi_name") or r["name"] for r in add_rows]
+    intel = _intel_for(conn, names)
+    entries: list[dict[str, Any]] = []
+    for match_row, name in zip(add_rows, names):
+        e = intel.get(name)
+        blockers: list[str] = []
+        signals_absent: list[str] = []
+        entry: dict[str, Any] = {
+            "pypi_name": name,
+            "readiness": None,
+            "template": None,
+            "blockers": blockers,
+            "signals_absent": signals_absent,
+            "latest_version": None,
+            "staged_recipes_pr_url": None,
+            "local_recipe": bool(match_row.get("local_recipe")),
+        }
+        if e is None or e["json_fetched_at"] is None:
+            # never enriched (skipped, failed, or not in the valid view) —
+            # the OSI check CANNOT pass on absent data (fail-closed)
+            signals_absent.append("pypi_enrichment")
+            blockers.append("license-unknown")
+            signals_absent.append("readiness_score")
+            entries.append(entry)
+            continue
+        entry["latest_version"] = e["latest_version"]
+        entry["readiness"] = e["conda_forge_readiness"]
+        entry["template"] = e["recommended_template"]
+        entry["staged_recipes_pr_url"] = e["staged_recipes_pr_url"]
+        entry["summary"] = e["summary"]
+        entry["packaging_shape"] = e["packaging_shape"]
+        if e["json_last_error"] == "HTTP 404":
+            blockers.append("pypi-project-gone")
+        if e["license_spdx"] is None:
+            blockers.append("license-unknown")  # enriched, still unresolvable
+        elif e["license_spdx"] not in _OSI_APPROVED_SPDX:
+            blockers.append(f"license-non-osi ({e['license_spdx']})")
+        if e["latest_yanked"]:
+            blockers.append("latest-yanked")
+        if e["conda_forge_readiness"] is None:
+            signals_absent.append("readiness_score")
+        entries.append(entry)
+    # readiness-desc, unscored last, name as tiebreak
+    entries.sort(key=lambda x: (-(x["readiness"] if x["readiness"] is not None
+                                  else -1), x["pypi_name"]))
+    return entries
+
+
+def nonpypi_entries(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """ADD-NONPYPI rows appended unscored — upstream identity as a purl."""
+    out = []
+    for r in sorted(rows, key=lambda x: x["name"]):
+        ver = f"@{r['pinned']}" if r.get("pinned") else ""
+        out.append({
+            "name": r["name"],
+            "ecosystem": r["ecosystem"],
+            "upstream_purl": f"pkg:{r['ecosystem']}/{r['name']}{ver}",
+        })
+    return out
+
+
+def run_handoff(
+    conn: sqlite3.Connection,
+    match_rows: list[dict[str, Any]],
+    fetcher: Fetcher | None = None,
+    enrich: bool = True,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    add_rows = [r for r in match_rows if r.get("bucket") == "ADD"]
+    nonpypi_rows = [r for r in match_rows if r.get("bucket") == "ADD-NONPYPI"]
+
+    enrichment: dict[str, Any] = {"skipped": True}
+    if enrich and add_rows:
+        names = [r.get("pypi_name") or r["name"] for r in add_rows]
+        enrichment = enrich_add_rows(conn, names, fetcher or _default_fetcher(),
+                                     limit=limit)
+
+    built = None
+    try:
+        row = conn.execute("SELECT value FROM meta WHERE key='built_at'").fetchone()
+        built = row[0] if row else None
+    except sqlite3.Error:
+        pass
+    return {
+        "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "built_at": built,
+        "add_count": len(add_rows),
+        "nonpypi_count": len(nonpypi_rows),
+        "enrichment": enrichment,
+        "worklist": build_worklist(conn, add_rows),
+        "nonpypi": nonpypi_entries(nonpypi_rows),
+    }
+
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+def render_report(result: dict[str, Any]) -> str:
+    lines = [
+        "# add-handoff packaging worklist",
+        "",
+        f"- generated_at: {result['generated_at']}",
+        f"- atlas built_at: {result['built_at']}",
+        f"- ADD rows: {result['add_count']:,} · ADD-NONPYPI: {result['nonpypi_count']:,}",
+    ]
+    enr = result["enrichment"]
+    if enr.get("skipped"):
+        lines.append("- enrichment: SKIPPED (--no-enrich) — un-enriched rows "
+                     "stay BLOCKED (license-unknown), never clean")
+    else:
+        lines.append(
+            f"- enrichment: {enr['fetched']} fetched, {enr['not_found']} gone "
+            f"(404), {enr['failed']} failed (stay eligible) of "
+            f"{enr['eligible']} needing")
+        if enr["dropped_by_limit"]:
+            lines.append(
+                f"- **--limit dropped {len(enr['dropped_by_limit'])} names "
+                f"(still un-enriched, still blocked):** "
+                + ", ".join(enr["dropped_by_limit"]))
+    lines += ["", "## Worklist (readiness-desc)", ""]
+    for e in result["worklist"]:
+        bits = [f"readiness {e['readiness'] if e['readiness'] is not None else '?'}"]
+        if e.get("latest_version"):
+            bits.append(f"v{e['latest_version']}")
+        if e.get("template"):
+            bits.append(e["template"])
+        if e["blockers"]:
+            bits.append("BLOCKERS: " + ", ".join(e["blockers"]))
+        if e.get("staged_recipes_pr_url"):
+            bits.append(f"PR in flight: {e['staged_recipes_pr_url']}")
+        if e.get("local_recipe"):
+            bits.append("local recipe present")
+        if e["signals_absent"]:
+            bits.append("signals_absent: " + ", ".join(e["signals_absent"]))
+        lines.append(f"- **{e['pypi_name']}** — {'; '.join(bits)}")
+    if not result["worklist"]:
+        lines.append("- (none)")
+    lines += ["", "## ADD-NONPYPI (unscored, upstream identity only)", ""]
+    for n in result["nonpypi"]:
+        lines.append(f"- **{n['name']}** ({n['ecosystem']}) — {n['upstream_purl']}")
+    if not result["nonpypi"]:
+        lines.append("- (none)")
+    return "\n".join(lines) + "\n"
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit the ADD-bucket packaging worklist from "
+                    "inventory-match results (bounded enrichment first).")
+    parser.add_argument("inputs", nargs="*", type=Path,
+                        help="Inventory inputs (run inventory-match inline)")
+    parser.add_argument("--matches", type=Path, default=None,
+                        help="Saved `inventory-match --json` result to consume "
+                             "instead of running the matcher")
+    parser.add_argument("--format", dest="format_", metavar="FMT", default=None,
+                        help="Forwarded to inventory-match for text inputs")
+    parser.add_argument("--no-enrich", dest="enrich", action="store_false",
+                        help="Offline: skip the bounded PyPI fetch (rows stay "
+                             "BLOCKED license-unknown — fail-closed)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Cap live fetches (dropped names are reported)")
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT_PATH,
+                        help=f"Markdown worklist path (default {DEFAULT_REPORT_PATH})")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit the full result as JSON on stdout")
+    parser.add_argument("--allow-stale", action="store_true",
+                        help="Bypass the 14-day atlas freshness gate (decision 6)")
+    args = parser.parse_args()
+
+    if bool(args.inputs) == bool(args.matches):
+        sys.stderr.write("give either INPUT files/dirs or --matches, not both/neither\n")
+        return 1
+    if not DB_PATH.exists():
+        sys.stderr.write(
+            f"cf_atlas.db not found at {DB_PATH}. "
+            "Run `pixi run -e local-recipes build-cf-atlas` first.\n")
+        return 1
+
+    # RW connection: enrichment writes ride the S2 discipline (idempotent
+    # upsert; --no-enrich never writes).
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        check_freshness(conn, args.allow_stale)
+        if args.matches:
+            doc = json.loads(args.matches.read_text(encoding="utf-8"))
+            match_rows = doc.get("rows")
+            if not isinstance(match_rows, list):
+                sys.stderr.write(f"--matches {args.matches}: no `rows` list "
+                                 "(is this `inventory-match --json` output?)\n")
+                return 1
+        else:
+            import inventory_match as im
+            deps, labels, warnings = im.load_inventory(args.inputs, args.format_)
+            for w in warnings:
+                sys.stderr.write(f"  warn: {w}\n")
+            if not deps:
+                sys.stderr.write("no dependencies parsed from any input\n")
+                return 1
+            match_rows = im.run(conn, deps, labels)["rows"]
+
+        result = run_handoff(conn, match_rows, enrich=args.enrich,
+                             limit=args.limit)
+    except StaleAtlasError as exc:
+        sys.stderr.write(f"REFUSED: {exc}\n")
+        return 1
+    except (sqlite3.OperationalError, json.JSONDecodeError, OSError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    finally:
+        conn.close()
+
+    report_text = render_report(result)
+    try:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(report_text, encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(f"  warn: could not write report to {args.report}: {exc}\n")
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        sys.stdout.write(report_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/conda-forge-expert/scripts/add_handoff.py
+++ b/.claude/skills/conda-forge-expert/scripts/add_handoff.py
@@ -80,9 +80,25 @@ def enrich_add_rows(
     """Bounded single-package enrichment for ADD names whose
     `pypi_intelligence` row lacks `json_fetched_at`. Idempotent by
     construction: already-enriched names are skipped up front, and the
-    upsert is Phase R's own. Returns counters + the enriched name list."""
+    upsert is Phase R's own. Returns counters + the enriched name list.
+
+    Names are de-duplicated (a name appearing in two manifests must not
+    burn two live fetches / two --limit slots), and names absent from
+    `pypi_universe` are NOT fetched — enriching them would mint exactly the
+    orphan `pypi_intelligence` rows the schema-v29 ORPHAN_RULE excludes."""
+    universe = {
+        r[0] for r in conn.execute("SELECT pypi_name FROM pypi_universe")
+    }
     needing: list[str] = []
+    not_in_universe: list[str] = []
+    seen: set[str] = set()
     for name in names:
+        if name in seen:
+            continue
+        seen.add(name)
+        if name not in universe:
+            not_in_universe.append(name)
+            continue
         # scope: eligibility probe, not version truth — mirrors Phase R's
         # own TTL query; NULL/missing json_fetched_at is exactly the signal.
         row = conn.execute(
@@ -119,6 +135,7 @@ def enrich_add_rows(
         "not_found": not_found,
         "failed": failed,
         "dropped_by_limit": dropped,
+        "not_in_universe": not_in_universe,
         "enriched_names": enriched_names,
     }
 
@@ -145,14 +162,23 @@ def _intel_for(conn: sqlite3.Connection, names: list[str]) -> dict[str, dict[str
     return out
 
 
+def _row_name(r: dict[str, Any]) -> str | None:
+    """The PyPI name of a match row: `pypi_name` (S5 always sets it for ADD)
+    then `name`. None for a malformed row (hand-edited --matches) — callers
+    skip those rather than KeyError."""
+    n = r.get("pypi_name") or r.get("name")
+    return n if isinstance(n, str) and n else None
+
+
 def build_worklist(
     conn: sqlite3.Connection, add_rows: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """One worklist entry per ADD row, blockers fail-closed on license."""
-    names = [r.get("pypi_name") or r["name"] for r in add_rows]
-    intel = _intel_for(conn, names)
+    paired = [(r, _row_name(r)) for r in add_rows]
+    paired = [(r, n) for r, n in paired if n is not None]
+    intel = _intel_for(conn, [n for _, n in paired])
     entries: list[dict[str, Any]] = []
-    for match_row, name in zip(add_rows, names):
+    for match_row, name in paired:
         e = intel.get(name)
         blockers: list[str] = []
         signals_absent: list[str] = []
@@ -198,14 +224,17 @@ def build_worklist(
 
 
 def nonpypi_entries(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """ADD-NONPYPI rows appended unscored — upstream identity as a purl."""
+    """ADD-NONPYPI rows appended unscored — upstream identity as a purl.
+    Malformed rows (no name; hand-edited --matches) are skipped."""
     out = []
-    for r in sorted(rows, key=lambda x: x["name"]):
+    valid = [r for r in rows if isinstance(r.get("name"), str) and r["name"]]
+    for r in sorted(valid, key=lambda x: x["name"]):
+        eco = r.get("ecosystem") or "generic"
         ver = f"@{r['pinned']}" if r.get("pinned") else ""
         out.append({
             "name": r["name"],
-            "ecosystem": r["ecosystem"],
-            "upstream_purl": f"pkg:{r['ecosystem']}/{r['name']}{ver}",
+            "ecosystem": eco,
+            "upstream_purl": f"pkg:{eco}/{r['name']}{ver}",
         })
     return out
 
@@ -222,14 +251,21 @@ def run_handoff(
 
     enrichment: dict[str, Any] = {"skipped": True}
     if enrich and add_rows:
-        names = [r.get("pypi_name") or r["name"] for r in add_rows]
+        names = [n for n in (_row_name(r) for r in add_rows) if n]
         enrichment = enrich_add_rows(conn, names, fetcher or _default_fetcher(),
                                      limit=limit)
 
     built = None
     try:
         row = conn.execute("SELECT value FROM meta WHERE key='built_at'").fetchone()
-        built = row[0] if row else None
+        if row:
+            # stored as a UNIX-epoch string — render ISO for the human report;
+            # fall back to the raw value if it isn't a parseable timestamp.
+            try:
+                built = dt.datetime.fromtimestamp(
+                    int(float(row[0])), dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            except (ValueError, TypeError):
+                built = row[0]
     except sqlite3.Error:
         pass
     return {
@@ -267,6 +303,11 @@ def render_report(result: dict[str, Any]) -> str:
                 f"- **--limit dropped {len(enr['dropped_by_limit'])} names "
                 f"(still un-enriched, still blocked):** "
                 + ", ".join(enr["dropped_by_limit"]))
+        if enr.get("not_in_universe"):
+            lines.append(
+                f"- **{len(enr['not_in_universe'])} ADD names not in "
+                f"pypi_universe (not fetched — would orphan; stale --matches?):** "
+                + ", ".join(enr["not_in_universe"]))
     lines += ["", "## Worklist (readiness-desc)", ""]
     for e in result["worklist"]:
         bits = [f"readiness {e['readiness'] if e['readiness'] is not None else '?'}"]
@@ -322,6 +363,9 @@ def main() -> int:
     if bool(args.inputs) == bool(args.matches):
         sys.stderr.write("give either INPUT files/dirs or --matches, not both/neither\n")
         return 1
+    if args.limit is not None and args.limit < 0:
+        sys.stderr.write("--limit must be >= 0\n")
+        return 1
     if not DB_PATH.exists():
         sys.stderr.write(
             f"cf_atlas.db not found at {DB_PATH}. "
@@ -335,7 +379,10 @@ def main() -> int:
         check_freshness(conn, args.allow_stale)
         if args.matches:
             doc = json.loads(args.matches.read_text(encoding="utf-8"))
-            match_rows = doc.get("rows")
+            # a bare JSON list (or any non-object) has no `rows` — guard the
+            # .get() so a hand-made/wrong file gets the friendly message,
+            # not an AttributeError traceback.
+            match_rows = doc.get("rows") if isinstance(doc, dict) else None
             if not isinstance(match_rows, list):
                 sys.stderr.write(f"--matches {args.matches}: no `rows` list "
                                  "(is this `inventory-match --json` output?)\n")

--- a/.claude/skills/conda-forge-expert/scripts/conda_forge_atlas.py
+++ b/.claude/skills/conda-forge-expert/scripts/conda_forge_atlas.py
@@ -8137,6 +8137,138 @@ def _phase_r_fetch_one(pypi_name: str
     return (pypi_name, None, last_err or "exhausted retries")
 
 
+def phase_r_upsert_one(
+    conn: sqlite3.Connection,
+    pypi_name: str,
+    payload: dict | None,
+    err: str | None,
+    now: int,
+) -> str:
+    """Parse one pypi.org/pypi/<name>/json result and upsert it into
+    `pypi_intelligence` (idempotent; INSERT OR IGNORE + UPDATE). The ONE
+    write path for per-project JSON enrichment — Phase R's bulk loop and
+    the S6 `add-handoff` bounded single-package enrichment both call this,
+    so parse semantics can never drift between them.
+
+    Returns 'fetched' | 'not_found' | 'failed'. A transient failure records
+    json_last_error but does NOT bump json_fetched_at (the row stays
+    eligible for the next run); a 404 bumps both (the project is gone).
+    """
+    if payload is not None and err is None:
+        info = payload.get("info") or {}
+        urls = payload.get("urls") or []
+        license_raw = info.get("license")
+        license_spdx = _normalize_license_to_spdx(license_raw)
+        # If license_raw is missing, also check classifiers for OSI tag
+        if not license_spdx:
+            for c in (info.get("classifiers") or []):
+                if isinstance(c, str) and c.lower().startswith("license ::"):
+                    sp = _normalize_license_to_spdx(c)
+                    if sp:
+                        license_spdx = sp
+                        break
+        summary = info.get("summary") or None
+        home_page = info.get("home_page") or None
+        proj_urls = info.get("project_urls") or {}
+        if not isinstance(proj_urls, dict):
+            proj_urls = {}
+        repo_url = proj_urls.get("Repository") or proj_urls.get("Source") or proj_urls.get("Source Code") or None
+        docs_url = proj_urls.get("Documentation") or proj_urls.get("Docs") or None
+        issues_url = proj_urls.get("Issues") or proj_urls.get("Bug Tracker") or proj_urls.get("Tracker") or None
+        requires_python = info.get("requires_python") or None
+        classifiers_json = json.dumps(info.get("classifiers") or [])
+        # Wheel coverage
+        has_wheel = 0
+        has_sdist = 0
+        wheel_platforms_set: set[str] = set()
+        python_tags_set: set[str] = set()
+        for u in urls:
+            if not isinstance(u, dict):
+                continue
+            pt = u.get("packagetype")
+            fn = u.get("filename") or ""
+            if pt == "bdist_wheel":
+                has_wheel = 1
+                # Filename: name-version-pythontag-abi-platform.whl
+                parts = fn.rsplit("-", 3)
+                if len(parts) == 4:
+                    python_tags_set.add(parts[1])
+                    wheel_platforms_set.add(parts[3].rsplit(".whl", 1)[0])
+            elif pt == "sdist":
+                has_sdist = 1
+        wheel_platforms_json = json.dumps(sorted(wheel_platforms_set))
+        python_tags_json = json.dumps(sorted(python_tags_set))
+        packaging_shape = _classify_packaging_shape(payload)
+        # Latest version info
+        latest_version = info.get("version") or None
+        latest_upload_at: int | None = None
+        latest_yanked: int | None = None
+        if latest_version:
+            rel = (payload.get("releases") or {}).get(latest_version) or []
+            if isinstance(rel, list) and rel:
+                # Use the most recent upload_time
+                for f in rel:
+                    t = _iso_to_unix_safe(f.get("upload_time_iso_8601") or f.get("upload_time"))
+                    if t and (latest_upload_at is None or t > latest_upload_at):
+                        latest_upload_at = t
+                # Yanked: all files yanked
+                latest_yanked = 1 if all(bool(f.get("yanked")) for f in rel) else 0
+        # Upsert
+        conn.execute(
+            "INSERT OR IGNORE INTO pypi_intelligence (pypi_name) VALUES (?)",
+            (pypi_name,),
+        )
+        conn.execute(
+            """
+            UPDATE pypi_intelligence SET
+                latest_version = ?, latest_upload_at = ?, latest_yanked = ?,
+                requires_python = ?,
+                license_raw = ?, license_spdx = ?,
+                summary = ?, home_page = ?, repo_url = ?, docs_url = ?, issues_url = ?,
+                classifiers = ?,
+                has_wheel = ?, has_sdist = ?,
+                wheel_platforms = ?, python_tags = ?,
+                packaging_shape = ?,
+                json_fetched_at = ?, json_last_error = NULL
+            WHERE pypi_name = ?
+            """,
+            (
+                latest_version, latest_upload_at, latest_yanked,
+                requires_python,
+                license_raw, license_spdx,
+                summary, home_page, repo_url, docs_url, issues_url,
+                classifiers_json,
+                has_wheel, has_sdist,
+                wheel_platforms_json, python_tags_json,
+                packaging_shape,
+                now, pypi_name,
+            ),
+        )
+        return "fetched"
+    if err == "HTTP 404":
+        conn.execute(
+            "INSERT OR IGNORE INTO pypi_intelligence (pypi_name) VALUES (?)",
+            (pypi_name,),
+        )
+        conn.execute(
+            "UPDATE pypi_intelligence SET json_last_error = ?, "
+            "json_fetched_at = ? WHERE pypi_name = ?",
+            (err, now, pypi_name),
+        )
+        return "not_found"
+    # Transient failure — record last_error but don't bump fetched_at
+    # (so the row stays eligible next run)
+    conn.execute(
+        "INSERT OR IGNORE INTO pypi_intelligence (pypi_name) VALUES (?)",
+        (pypi_name,),
+    )
+    conn.execute(
+        "UPDATE pypi_intelligence SET json_last_error = ? WHERE pypi_name = ?",
+        (err or "unknown error", pypi_name),
+    )
+    return "failed"
+
+
 def phase_r_pypi_json_enrich(conn: sqlite3.Connection) -> dict:
     """Phase R: per-project JSON enrichment for the top-N candidate slice.
 
@@ -8243,119 +8375,12 @@ def phase_r_pypi_json_enrich(conn: sqlite3.Connection) -> dict:
         futures = [ex.submit(_phase_r_fetch_one, r["pypi_name"]) for r in candidates]
         for fut in as_completed(futures):
             pypi_name, payload, err = fut.result()
-            if payload is not None and err is None:
-                info = payload.get("info") or {}
-                urls = payload.get("urls") or []
-                license_raw = info.get("license")
-                license_spdx = _normalize_license_to_spdx(license_raw)
-                # If license_raw is missing, also check classifiers for OSI tag
-                if not license_spdx:
-                    for c in (info.get("classifiers") or []):
-                        if isinstance(c, str) and c.lower().startswith("license ::"):
-                            sp = _normalize_license_to_spdx(c)
-                            if sp:
-                                license_spdx = sp
-                                break
-                summary = info.get("summary") or None
-                home_page = info.get("home_page") or None
-                proj_urls = info.get("project_urls") or {}
-                if not isinstance(proj_urls, dict):
-                    proj_urls = {}
-                repo_url = proj_urls.get("Repository") or proj_urls.get("Source") or proj_urls.get("Source Code") or None
-                docs_url = proj_urls.get("Documentation") or proj_urls.get("Docs") or None
-                issues_url = proj_urls.get("Issues") or proj_urls.get("Bug Tracker") or proj_urls.get("Tracker") or None
-                requires_python = info.get("requires_python") or None
-                classifiers_json = json.dumps(info.get("classifiers") or [])
-                # Wheel coverage
-                has_wheel = 0
-                has_sdist = 0
-                wheel_platforms_set: set[str] = set()
-                python_tags_set: set[str] = set()
-                for u in urls:
-                    if not isinstance(u, dict):
-                        continue
-                    pt = u.get("packagetype")
-                    fn = u.get("filename") or ""
-                    if pt == "bdist_wheel":
-                        has_wheel = 1
-                        # Filename: name-version-pythontag-abi-platform.whl
-                        parts = fn.rsplit("-", 3)
-                        if len(parts) == 4:
-                            python_tags_set.add(parts[1])
-                            wheel_platforms_set.add(parts[3].rsplit(".whl", 1)[0])
-                    elif pt == "sdist":
-                        has_sdist = 1
-                wheel_platforms_json = json.dumps(sorted(wheel_platforms_set))
-                python_tags_json = json.dumps(sorted(python_tags_set))
-                packaging_shape = _classify_packaging_shape(payload)
-                # Latest version info
-                latest_version = info.get("version") or None
-                latest_upload_at: int | None = None
-                latest_yanked: int | None = None
-                if latest_version:
-                    rel = (payload.get("releases") or {}).get(latest_version) or []
-                    if isinstance(rel, list) and rel:
-                        # Use the most recent upload_time
-                        for f in rel:
-                            t = _iso_to_unix_safe(f.get("upload_time_iso_8601") or f.get("upload_time"))
-                            if t and (latest_upload_at is None or t > latest_upload_at):
-                                latest_upload_at = t
-                        # Yanked: all files yanked
-                        latest_yanked = 1 if all(bool(f.get("yanked")) for f in rel) else 0
-                # Upsert
-                conn.execute(
-                    "INSERT OR IGNORE INTO pypi_intelligence (pypi_name) VALUES (?)",
-                    (pypi_name,),
-                )
-                conn.execute(
-                    """
-                    UPDATE pypi_intelligence SET
-                        latest_version = ?, latest_upload_at = ?, latest_yanked = ?,
-                        requires_python = ?,
-                        license_raw = ?, license_spdx = ?,
-                        summary = ?, home_page = ?, repo_url = ?, docs_url = ?, issues_url = ?,
-                        classifiers = ?,
-                        has_wheel = ?, has_sdist = ?,
-                        wheel_platforms = ?, python_tags = ?,
-                        packaging_shape = ?,
-                        json_fetched_at = ?, json_last_error = NULL
-                    WHERE pypi_name = ?
-                    """,
-                    (
-                        latest_version, latest_upload_at, latest_yanked,
-                        requires_python,
-                        license_raw, license_spdx,
-                        summary, home_page, repo_url, docs_url, issues_url,
-                        classifiers_json,
-                        has_wheel, has_sdist,
-                        wheel_platforms_json, python_tags_json,
-                        packaging_shape,
-                        now, pypi_name,
-                    ),
-                )
+            outcome = phase_r_upsert_one(conn, pypi_name, payload, err, now)
+            if outcome == "fetched":
                 fetched += 1
-            elif err == "HTTP 404":
-                conn.execute(
-                    "INSERT OR IGNORE INTO pypi_intelligence (pypi_name) VALUES (?)",
-                    (pypi_name,),
-                )
-                conn.execute(
-                    "UPDATE pypi_intelligence SET json_last_error = ?, "
-                    "json_fetched_at = ? WHERE pypi_name = ?",
-                    (err, now, pypi_name),
-                )
+            elif outcome == "not_found":
                 not_found += 1
             else:
-                # Transient failure — record last_error but don't bump fetched_at
-                # (so the row stays eligible next run)
-                conn.execute(
-                    "INSERT OR IGNORE INTO pypi_intelligence (pypi_name) VALUES (?)",
-                    (pypi_name,),
-                )
-                conn.execute(
-                    "UPDATE pypi_intelligence SET json_last_error = ? WHERE pypi_name = ?",
-                    (err or "unknown error", pypi_name),
-                )
                 failed += 1
             completed += 1
             if completed % progress_every == 0:
@@ -8398,6 +8423,68 @@ _PACKAGING_SHAPE_TO_TEMPLATE: dict[str, str | None] = {
 }
 
 
+def apply_readiness_scores(
+    conn: sqlite3.Connection, names: list[str] | None = None,
+) -> int:
+    """The canonical Phase S readiness UPDATE (0-100 composite +
+    recommended_template). `names=None` scores the whole table (Phase S);
+    a name list scopes it to a slice (S6 `add-handoff` re-scores freshly
+    enriched rows with the SAME formula — no parallel scorer to drift).
+    Rows with no Phase R enrichment (json_fetched_at IS NULL) are always
+    skipped: their score would be meaningless. Commits; returns rowcount."""
+    now = int(time.time())
+    two_years_ago = now - 2 * 365 * 86400
+
+    # OSI-approved SPDX set inlined as SQL CASE (~25 values). Keep in sync
+    # with _OSI_APPROVED_SPDX above.
+    osi_set_sql = "(" + ",".join(f"'{lic}'" for lic in sorted(_OSI_APPROVED_SPDX)) + ")"
+
+    scope_sql = ""
+    params: list = []
+    if names is not None:
+        if not names:
+            return 0
+        scope_sql = " AND pypi_name IN (" + ",".join("?" for _ in names) + ")"
+        params = list(names)
+
+    # Single UPDATE — all components computed inline.
+    updated = conn.execute(
+        f"""
+        UPDATE pypi_intelligence
+        SET
+            conda_forge_readiness = (
+                CASE WHEN license_spdx IN {osi_set_sql} THEN 25 ELSE 0 END
+              + CASE
+                    WHEN requires_python IS NULL THEN 20
+                    WHEN requires_python LIKE '%>=3.1%' OR requires_python LIKE '%>=3.2%' THEN 20
+                    WHEN requires_python LIKE '%>=3.9%' THEN 10
+                    ELSE 0
+                END
+              + CASE WHEN repo_url IS NOT NULL THEN 15 ELSE 0 END
+              + CASE WHEN latest_upload_at IS NOT NULL AND latest_upload_at >= {two_years_ago} THEN 15 ELSE 0 END
+              + CASE WHEN has_sdist = 1 THEN 10 ELSE 0 END
+              + CASE
+                    WHEN packaging_shape IN ('pure-python','rust-pyo3','cython') THEN 15
+                    WHEN packaging_shape = 'c-extension' THEN 7
+                    ELSE 0
+                END
+            ),
+            recommended_template = CASE packaging_shape
+                WHEN 'pure-python'  THEN 'templates/python/recipe.yaml'
+                WHEN 'rust-pyo3'    THEN 'templates/python/maturin-recipe.yaml'
+                WHEN 'cython'       THEN 'templates/python/compiled-recipe.yaml'
+                WHEN 'c-extension'  THEN 'templates/python/compiled-recipe.yaml'
+                ELSE NULL
+            END,
+            score_calc_at = {now}
+        WHERE json_fetched_at IS NOT NULL{scope_sql}
+        """,
+        params,
+    ).rowcount
+    conn.commit()
+    return updated
+
+
 def phase_s_computed_scores(conn: sqlite3.Connection) -> dict:
     """Phase S: compute conda_forge_readiness + recommended_template.
 
@@ -8435,49 +8522,7 @@ def phase_s_computed_scores(conn: sqlite3.Connection) -> dict:
             "duration_seconds": round(elapsed, 1),
         }
 
-    now = int(time.time())
-    two_years_ago = now - 2 * 365 * 86400
-
-    # OSI-approved SPDX set inlined as SQL CASE (~25 values). Keep in sync
-    # with _OSI_APPROVED_SPDX above.
-    osi_set_sql = "(" + ",".join(f"'{lic}'" for lic in sorted(_OSI_APPROVED_SPDX)) + ")"
-
-    # Single UPDATE — all components computed inline. Skip rows with no
-    # Phase R enrichment (json_fetched_at IS NULL) since their score
-    # would be meaningless.
-    updated = conn.execute(
-        f"""
-        UPDATE pypi_intelligence
-        SET
-            conda_forge_readiness = (
-                CASE WHEN license_spdx IN {osi_set_sql} THEN 25 ELSE 0 END
-              + CASE
-                    WHEN requires_python IS NULL THEN 20
-                    WHEN requires_python LIKE '%>=3.1%' OR requires_python LIKE '%>=3.2%' THEN 20
-                    WHEN requires_python LIKE '%>=3.9%' THEN 10
-                    ELSE 0
-                END
-              + CASE WHEN repo_url IS NOT NULL THEN 15 ELSE 0 END
-              + CASE WHEN latest_upload_at IS NOT NULL AND latest_upload_at >= {two_years_ago} THEN 15 ELSE 0 END
-              + CASE WHEN has_sdist = 1 THEN 10 ELSE 0 END
-              + CASE
-                    WHEN packaging_shape IN ('pure-python','rust-pyo3','cython') THEN 15
-                    WHEN packaging_shape = 'c-extension' THEN 7
-                    ELSE 0
-                END
-            ),
-            recommended_template = CASE packaging_shape
-                WHEN 'pure-python'  THEN 'templates/python/recipe.yaml'
-                WHEN 'rust-pyo3'    THEN 'templates/python/maturin-recipe.yaml'
-                WHEN 'cython'       THEN 'templates/python/compiled-recipe.yaml'
-                WHEN 'c-extension'  THEN 'templates/python/compiled-recipe.yaml'
-                ELSE NULL
-            END,
-            score_calc_at = {now}
-        WHERE json_fetched_at IS NOT NULL
-        """,
-    ).rowcount
-    conn.commit()
+    updated = apply_readiness_scores(conn)
 
     # Summary stats
     # scope: Phase S producer-side readiness histogram over the whole

--- a/.claude/skills/conda-forge-expert/scripts/conda_forge_atlas.py
+++ b/.claude/skills/conda-forge-expert/scripts/conda_forge_atlas.py
@@ -8100,40 +8100,53 @@ _CPYTHON_ABI_RE = re.compile(r"cp3\d+-cp3\d+")
 
 def _phase_r_fetch_one(pypi_name: str
                        ) -> tuple[str, dict | None, str | None]:
-    """Worker for Phase R. Returns (pypi_name, json_doc_or_None, err).
+    """Worker for Phase R (and the S6 add-handoff bounded enrichment).
+    Returns (pypi_name, json_doc_or_None, err).
 
-    Hits https://pypi.org/pypi/<name>/json. Same retry shape as
-    `_phase_h_fetch_one` — 3 attempts with Retry-After honored on 429/503
-    and ±25% jitter on exponential backoff otherwise.
+    Routes through `_http.resolve_pypi_json_urls` (PYPI_JSON_BASE_URL env /
+    pixi `pypi-config.index-url` mirror / pypi.org fallback) so air-gapped
+    JFrog setups reach their mirror — the same enterprise-routing chain
+    `recipe_updater` / `recipe-generator` use. Each URL in the chain gets
+    the `_phase_h_fetch_one` retry shape (3 attempts, Retry-After on
+    429/503, ±25% jitter); a 404 is definitive (short-circuits the whole
+    chain), other failures fall through to the next mirror.
     """
     import random as _random
-    url = f"https://pypi.org/pypi/{pypi_name}/json"
+    try:
+        from _http import resolve_pypi_json_urls  # type: ignore[import-not-found]
+        urls = resolve_pypi_json_urls(pypi_name)
+    except Exception:
+        urls = [f"https://pypi.org/pypi/{pypi_name}/json"]
+
     last_err: str | None = None
-    for attempt in range(3):
-        try:
-            req = _make_req(url)
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                payload = json.load(resp)
-            return (pypi_name, payload, None)
-        except urllib.error.HTTPError as e:
-            last_err = f"HTTP {e.code}"
-            if e.code == 404:
-                return (pypi_name, None, "HTTP 404")
-            if e.code in (429, 503) and attempt < 2:
-                retry_after = e.headers.get("Retry-After") if e.headers else None
-                base = 2.0 ** attempt + 1.0
-                jitter = base * (0.75 + 0.5 * _random.random())
-                sleep_for = _parse_retry_after(retry_after, fallback=jitter)
-                time.sleep(sleep_for)
-                continue
-            return (pypi_name, None, last_err)
-        except Exception as e:
-            last_err = f"{type(e).__name__}: {str(e)[:120]}"
-            if attempt < 2:
-                base = 1.0 + attempt
-                time.sleep(base * (0.75 + 0.5 * _random.random()))
-                continue
-            return (pypi_name, None, last_err)
+    for url in urls:
+        for attempt in range(3):
+            try:
+                req = _make_req(url)
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    payload = json.load(resp)
+                return (pypi_name, payload, None)
+            except urllib.error.HTTPError as e:
+                last_err = f"HTTP {e.code}"
+                if e.code == 404:
+                    # definitive: the project does not exist on this index —
+                    # trying another mirror would only mask a real 404
+                    return (pypi_name, None, "HTTP 404")
+                if e.code in (429, 503) and attempt < 2:
+                    retry_after = e.headers.get("Retry-After") if e.headers else None
+                    base = 2.0 ** attempt + 1.0
+                    jitter = base * (0.75 + 0.5 * _random.random())
+                    sleep_for = _parse_retry_after(retry_after, fallback=jitter)
+                    time.sleep(sleep_for)
+                    continue
+                break  # non-retryable HTTP — try the next mirror
+            except Exception as e:
+                last_err = f"{type(e).__name__}: {str(e)[:120]}"
+                if attempt < 2:
+                    base = 1.0 + attempt
+                    time.sleep(base * (0.75 + 0.5 * _random.random()))
+                    continue
+                break  # exhausted retries on this URL — try the next mirror
     return (pypi_name, None, last_err or "exhausted retries")
 
 

--- a/.claude/skills/conda-forge-expert/tests/meta/test_all_scripts_runnable.py
+++ b/.claude/skills/conda-forge-expert/tests/meta/test_all_scripts_runnable.py
@@ -10,6 +10,7 @@ import pytest
 
 # Hyphenated and underscored — no exclusions
 SCRIPTS = [
+    "add_handoff.py",
     "adoption_stage.py",
     "atlas_phase.py",
     "behind_upstream.py",

--- a/.claude/skills/conda-forge-expert/tests/unit/test_add_handoff.py
+++ b/.claude/skills/conda-forge-expert/tests/unit/test_add_handoff.py
@@ -252,6 +252,41 @@ class TestWorklistShape:
         result = ah.run_handoff(db, rows, enrich=False)
         assert result["add_count"] == 0 and result["worklist"] == []
 
+    def test_duplicate_names_fetched_once(self, ah, db):
+        fetcher = _fake_fetcher({"goodpkg": _payload("goodpkg")})
+        result = ah.run_handoff(
+            db, [_add_row("goodpkg"), _add_row("goodpkg")], fetcher=fetcher)
+        assert fetcher.calls == ["goodpkg"]          # deduped, one live fetch
+        # both rows still appear in the worklist (dedup is on FETCH, not display)
+        assert len(result["worklist"]) == 2
+
+    def test_not_in_universe_name_not_fetched(self, ah, db):
+        """An ADD name absent from pypi_universe (stale --matches) is NOT
+        live-fetched — that would mint the orphan pypi_intelligence row the
+        ORPHAN_RULE excludes — and is reported."""
+        fetcher = _fake_fetcher({"orphanpkg": _payload("orphanpkg")})
+        result = ah.run_handoff(db, [_add_row("orphanpkg")], fetcher=fetcher)
+        assert fetcher.calls == []
+        assert "orphanpkg" in result["enrichment"]["not_in_universe"]
+        # no orphan row minted
+        assert db.execute("SELECT COUNT(*) FROM pypi_intelligence "
+                          "WHERE pypi_name='orphanpkg'").fetchone()[0] == 0
+        assert "not in" in ah.render_report(result)
+
+    def test_malformed_matches_rows_skipped_not_crash(self, ah, db):
+        rows = [
+            {"bucket": "ADD"},                       # no name at all
+            _add_row("prescored"),
+            {"bucket": "ADD-NONPYPI", "pinned": "1.0"},   # no name/ecosystem
+        ]
+        result = ah.run_handoff(db, rows, enrich=False)
+        assert [e["pypi_name"] for e in result["worklist"]] == ["prescored"]
+        assert result["nonpypi"] == []              # nameless nonpypi skipped
+
+    def test_built_at_rendered_iso(self, ah, db):
+        result = ah.run_handoff(db, [_add_row("prescored")], enrich=False)
+        assert result["built_at"].endswith("Z") and "T" in result["built_at"]
+
     def test_in_flight_pr_and_local_recipe_surfaced(self, ah, db):
         db.execute("UPDATE pypi_intelligence SET staged_recipes_pr_url = "
                    "'https://github.com/conda-forge/staged-recipes/pull/12345' "

--- a/.claude/skills/conda-forge-expert/tests/unit/test_add_handoff.py
+++ b/.claude/skills/conda-forge-expert/tests/unit/test_add_handoff.py
@@ -1,0 +1,266 @@
+"""add-handoff CLI — the S6 ADD-bucket packaging worklist.
+
+cyclonedx-universe-inventory Wave C / S6. Pins: the bounded injectable
+enrichment (Phase R's own upsert — idempotency proven by a zero-fetch
+second run), canonical-formula re-scoring scoped to the slice, the
+FAIL-CLOSED license rule (NULL license_spdx == `license-unknown` blocker,
+never a silent pass — including under --no-enrich), --limit reporting
+dropped names, 404/transient-failure semantics, readiness-desc ordering,
+and ADD-NONPYPI appended unscored with purl identity.
+
+The LIVE fetch path (`_phase_r_fetch_one` over the network) is the LOCAL
+wave; every test here injects a fake fetcher.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+def _load(name: str):
+    path = _SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def atlas_mod():
+    return _load("conda_forge_atlas")
+
+
+@pytest.fixture(scope="module")
+def ah():
+    return _load("add_handoff")
+
+
+NOW = int(time.time())
+
+
+def _payload(name: str, *, license_str: str = "MIT", yanked: bool = False,
+             requires_python: str = ">=3.10") -> dict:
+    """A minimal but realistic pypi.org/pypi/<name>/json document that
+    scores 100 by the canonical formula when defaults are used."""
+    version = "2.0.0"
+    return {
+        "info": {
+            "name": name,
+            "version": version,
+            "license": license_str,
+            "requires_python": requires_python,
+            "summary": f"{name} does things",
+            "project_urls": {"Repository": f"https://github.com/acme/{name}"},
+            "classifiers": [],
+        },
+        "urls": [
+            {"packagetype": "sdist", "filename": f"{name}-{version}.tar.gz",
+             "yanked": yanked},
+            {"packagetype": "bdist_wheel",
+             "filename": f"{name}-{version}-py3-none-any.whl", "yanked": yanked},
+        ],
+        "releases": {
+            version: [
+                {"packagetype": "sdist",
+                 "upload_time_iso_8601": time.strftime(
+                     "%Y-%m-%dT%H:%M:%SZ", time.gmtime(NOW - 5 * 86400)),
+                 "yanked": yanked},
+            ],
+        },
+    }
+
+
+def _fake_fetcher(responses: dict):
+    """responses: name → payload dict | 'HTTP 404' | 'HTTP 503'."""
+    calls: list[str] = []
+
+    def fetch(name: str):
+        calls.append(name)
+        r = responses.get(name)
+        if isinstance(r, dict):
+            return (name, r, None)
+        return (name, None, r or "HTTP 404")
+
+    fetch.calls = calls  # type: ignore[attr-defined]
+    return fetch
+
+
+def _add_row(name: str, **kw) -> dict:
+    return {"name": name, "pypi_name": name, "ecosystem": "pypi",
+            "bucket": "ADD", **kw}
+
+
+@pytest.fixture
+def db(tmp_path, atlas_mod):
+    conn = atlas_mod.open_db(tmp_path / "cf_atlas.db")
+    atlas_mod.init_schema(conn)
+    for name in ("goodpkg", "nonosipkg", "ghostpkg", "flakypkg", "yankedpkg",
+                 "prescored"):
+        conn.execute(
+            "INSERT INTO pypi_universe (pypi_name, last_serial, fetched_at) "
+            "VALUES (?, 1, ?)", (name, NOW),
+        )
+    # already-enriched row: non-OSI license, mid readiness — no fetch needed
+    conn.execute(
+        "INSERT INTO pypi_intelligence (pypi_name, latest_version, license_spdx, "
+        "conda_forge_readiness, recommended_template, json_fetched_at, has_sdist, "
+        "packaging_shape) VALUES ('prescored', '1.0', 'CC-BY-4.0', 55, "
+        "'templates/python/recipe.yaml', ?, 1, 'pure-python')", (NOW,),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO meta(key, value) VALUES ('built_at', ?)", (str(NOW),),
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+class TestEnrichment:
+    def test_fetch_upsert_score_via_canonical_paths(self, ah, db):
+        fetcher = _fake_fetcher({"goodpkg": _payload("goodpkg")})
+        result = ah.run_handoff(db, [_add_row("goodpkg")], fetcher=fetcher)
+        assert result["enrichment"]["fetched"] == 1
+        entry = result["worklist"][0]
+        # canonical Phase S formula: OSI 25 + py>=3.10 20 + repo 15 +
+        # recent 15 + sdist 10 + pure-python 15 = 100
+        assert entry["readiness"] == 100
+        assert entry["template"] == "templates/python/recipe.yaml"
+        assert entry["blockers"] == []
+
+    def test_second_run_is_zero_fetch(self, ah, db):
+        """Idempotency proof — json_fetched_at set by run 1 makes run 2
+        skip the name entirely (the S2 write-path discipline)."""
+        fetcher = _fake_fetcher({"goodpkg": _payload("goodpkg")})
+        ah.run_handoff(db, [_add_row("goodpkg")], fetcher=fetcher)
+        ah.run_handoff(db, [_add_row("goodpkg")], fetcher=fetcher)
+        assert fetcher.calls == ["goodpkg"]          # exactly one live fetch
+
+    def test_already_enriched_never_fetched(self, ah, db):
+        fetcher = _fake_fetcher({})
+        result = ah.run_handoff(db, [_add_row("prescored")], fetcher=fetcher)
+        assert fetcher.calls == []
+        assert result["worklist"][0]["readiness"] == 55
+
+    def test_limit_drops_are_reported_not_silent(self, ah, db):
+        fetcher = _fake_fetcher({"goodpkg": _payload("goodpkg"),
+                                 "flakypkg": _payload("flakypkg")})
+        result = ah.run_handoff(
+            db, [_add_row("goodpkg"), _add_row("flakypkg")],
+            fetcher=fetcher, limit=1)
+        enr = result["enrichment"]
+        assert enr["fetched"] == 1
+        assert enr["dropped_by_limit"] == ["flakypkg"]
+        report = ah.render_report(result)
+        assert "flakypkg" in report and "dropped" in report
+
+    def test_404_is_an_answer_transient_stays_eligible(self, ah, db):
+        fetcher = _fake_fetcher({"ghostpkg": "HTTP 404", "flakypkg": "HTTP 503"})
+        ah.run_handoff(db, [_add_row("ghostpkg"), _add_row("flakypkg")],
+                       fetcher=fetcher)
+        # 404 bumps json_fetched_at (project gone — do not refetch) …
+        got = db.execute("SELECT json_fetched_at, json_last_error FROM "
+                         "pypi_intelligence WHERE pypi_name='ghostpkg'").fetchone()
+        assert got[0] is not None and got[1] == "HTTP 404"
+        # … transient failure does NOT (stays eligible for the next run)
+        got = db.execute("SELECT json_fetched_at FROM pypi_intelligence "
+                         "WHERE pypi_name='flakypkg'").fetchone()
+        assert got[0] is None
+        fetcher2 = _fake_fetcher({"flakypkg": _payload("flakypkg")})
+        result = ah.run_handoff(db, [_add_row("ghostpkg"), _add_row("flakypkg")],
+                                fetcher=fetcher2)
+        assert fetcher2.calls == ["flakypkg"]        # ghost not retried
+        assert result["enrichment"]["fetched"] == 1
+
+
+class TestFailClosedLicense:
+    def test_no_enrich_rows_stay_blocked(self, ah, db):
+        """--no-enrich must NEVER let a NULL license pass the OSI check."""
+        result = ah.run_handoff(db, [_add_row("goodpkg")], enrich=False)
+        entry = result["worklist"][0]
+        assert "license-unknown" in entry["blockers"]
+        assert "pypi_enrichment" in entry["signals_absent"]
+        report = ah.render_report(result)
+        assert "SKIPPED" in report
+
+    def test_enriched_but_unresolvable_license_blocks(self, ah, db):
+        fetcher = _fake_fetcher(
+            {"goodpkg": _payload("goodpkg", license_str="Proprietary :: Custom")})
+        result = ah.run_handoff(db, [_add_row("goodpkg")], fetcher=fetcher)
+        assert "license-unknown" in result["worklist"][0]["blockers"]
+
+    def test_non_osi_license_blocks_with_id(self, ah, db):
+        result = ah.run_handoff(db, [_add_row("prescored")], enrich=False)
+        assert result["worklist"][0]["blockers"] == ["license-non-osi (CC-BY-4.0)"]
+
+    def test_gone_project_blocked(self, ah, db):
+        fetcher = _fake_fetcher({"ghostpkg": "HTTP 404"})
+        result = ah.run_handoff(db, [_add_row("ghostpkg")], fetcher=fetcher)
+        blockers = result["worklist"][0]["blockers"]
+        assert "pypi-project-gone" in blockers
+        assert "license-unknown" in blockers
+
+    def test_yanked_latest_blocked(self, ah, db):
+        fetcher = _fake_fetcher({"yankedpkg": _payload("yankedpkg", yanked=True)})
+        result = ah.run_handoff(db, [_add_row("yankedpkg")], fetcher=fetcher)
+        assert "latest-yanked" in result["worklist"][0]["blockers"]
+
+
+class TestWorklistShape:
+    def test_readiness_desc_unscored_last(self, ah, db):
+        fetcher = _fake_fetcher({"goodpkg": _payload("goodpkg"),
+                                 "flakypkg": "HTTP 503"})
+        result = ah.run_handoff(
+            db, [_add_row("flakypkg"), _add_row("prescored"), _add_row("goodpkg")],
+            fetcher=fetcher)
+        names = [e["pypi_name"] for e in result["worklist"]]
+        assert names == ["goodpkg", "prescored", "flakypkg"]  # 100, 55, unscored
+
+    def test_nonpypi_appended_unscored_with_purl(self, ah, db):
+        rows = [
+            _add_row("prescored"),
+            {"name": "left-pad", "ecosystem": "npm", "bucket": "ADD-NONPYPI",
+             "pinned": "1.3.0"},
+            {"name": "ripgrep", "ecosystem": "cargo", "bucket": "ADD-NONPYPI",
+             "pinned": None},
+        ]
+        result = ah.run_handoff(db, rows, enrich=False)
+        assert result["nonpypi"] == [
+            {"name": "left-pad", "ecosystem": "npm",
+             "upstream_purl": "pkg:npm/left-pad@1.3.0"},
+            {"name": "ripgrep", "ecosystem": "cargo",
+             "upstream_purl": "pkg:cargo/ripgrep"},
+        ]
+        report = ah.render_report(result)
+        assert "pkg:npm/left-pad@1.3.0" in report
+
+    def test_non_add_buckets_ignored(self, ah, db):
+        rows = [
+            {"name": "numpy", "ecosystem": "pypi", "bucket": "CURRENT"},
+            {"name": "olddep", "ecosystem": "pypi", "bucket": "UPDATE-FEEDSTOCK"},
+        ]
+        result = ah.run_handoff(db, rows, enrich=False)
+        assert result["add_count"] == 0 and result["worklist"] == []
+
+    def test_in_flight_pr_and_local_recipe_surfaced(self, ah, db):
+        db.execute("UPDATE pypi_intelligence SET staged_recipes_pr_url = "
+                   "'https://github.com/conda-forge/staged-recipes/pull/12345' "
+                   "WHERE pypi_name = 'prescored'")
+        db.commit()
+        result = ah.run_handoff(
+            db, [_add_row("prescored", local_recipe=True)], enrich=False)
+        entry = result["worklist"][0]
+        assert entry["staged_recipes_pr_url"].endswith("/pull/12345")
+        assert entry["local_recipe"] is True
+        report = ah.render_report(result)
+        assert "PR in flight" in report and "local recipe present" in report

--- a/docs/specs/cyclonedx-universe-inventory.md
+++ b/docs/specs/cyclonedx-universe-inventory.md
@@ -81,9 +81,11 @@ spec_updated: 2026-07-05
   `uncorroborated` live-gate fix `4821907ab0`). **Wave B shipped 2026-07-05**
   (web slice `dd54e47d4d` + adversarial patches `5e39ffe293`, PR #33; local
   live gates ALL PASS 2026-07-05 — see § Wave B Dev Notes). **Wave C S5+S5a
-  web slice shipped 2026-07-05** (`44ea734` + adversarial patches, branch
-  `claude/wave-c-inventory-match`; S6 and the Wave C local gates remain).
-  Resume at **Wave C local gates / S6**.
+  web slice shipped 2026-07-05** (`44ea734` + adversarial patches, PR #34
+  merged `29542f3`). **Wave C S6 web slice shipped 2026-07-05**
+  (`2800eb2` + adversarial/Gemini patches, PR #35, branch
+  `claude/wave-c-s6-add-handoff`; the Wave C local gates remain). Resume at
+  **Wave C local gates**, then **Wave D / S7**.
 
 ### Execution-environment split (web pass)
 
@@ -124,6 +126,17 @@ grayskull cache) does **not** exist there, and `pixi` is not installed:
   S5 end-to-end smoke (real pixi.toml env + real SBOM, hand-verified bucket
   members incl. the G10-rename / stale-atlas / unreliable-comparison /
   non-Python-GitHub-upstream cases).
+  **Wave C S6 local-only additions (recorded 2026-07-05, with the S6 web
+  slice):** the bounded live `pypi.org/pypi/<name>/json` enrichment of
+  ADD-bucket names — the web slice injects a fake fetcher in every test and
+  defers the real `_phase_r_fetch_one` worker (now mirror-routed via
+  `_http.resolve_pypi_json_urls`, so air-gapped JFrog reaches its mirror) to
+  the local run; and the § Verification S6 hand-check that a real ADD slice
+  enriches, scores readiness-desc, and blocks non-OSI/unknown-license/gone
+  projects. Idempotency (`--no-enrich` offline mode + zero-fetch re-run) is
+  covered by the web fixture tests. The extracted `phase_r_upsert_one` /
+  `apply_readiness_scores(names=…)` helpers are the SAME write/score paths
+  Phase R/S bulk use — no parallel scorer to drift.
 
 ### Adjacent prefix.dev / nebari tooling (survey 2026-07-05, per user — the eighth amendment)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -418,6 +418,10 @@ cmd = "python .claude/scripts/conda-forge-expert/universe_sbom.py"
 description = "Match a user inventory (manifests / locks / SBOMs / pip+conda list text) against cf_atlas.db: ADD / ADD-NONPYPI / UPDATE-FEEDSTOCK / UPDATE-PIN / CURRENT / UNKNOWN buckets via three-way version comparison, freshness percentile, optional --policy CI gate (exit 2 on violations) + --weights sidecar; --sbom-in/--sbom-out annotates the BOM with cfe:gap_status. cyclonedx-universe-inventory Wave C/S5."
 cmd = "python .claude/scripts/conda-forge-expert/inventory_match.py"
 
+[feature.local-recipes.tasks.add-handoff]
+description = "Emit the ADD-bucket packaging worklist from inventory-match results (name, readiness, template, blockers e.g. non-OSI license, signals_absent; ADD-NONPYPI appended unscored). Runs a bounded Phase-R-style single-package PyPI enrichment BEFORE scoring (idempotent pypi_intelligence upsert; --no-enrich for offline, --limit N caps fetches with dropped names reported). --matches RESULT.json consumes a saved inventory-match --json run. cyclonedx-universe-inventory Wave C/S6."
+cmd = "python .claude/scripts/conda-forge-expert/add_handoff.py"
+
 [feature.local-recipes.tasks.pypi-intelligence]
 description = "Surface PyPI candidates with rich enrichment filters (schema v22+ pypi_intelligence). --not-in-conda-forge, --activity hot|warm|cold|dormant, --license-ok, --noarch-python-candidate, --min-downloads N, --in-bioconda / --in-pytorch / etc., --score-min N, --sort-by score|downloads|serial|name, --limit N, --json. Admin/maintainer-persona ranked candidate list with conda_forge_readiness scores."
 cmd = "python .claude/scripts/conda-forge-expert/pypi_intelligence.py"


### PR DESCRIPTION
## Summary

Implements the `add-handoff` CLI tool (Wave C / S6 specification) to generate a ready-to-consume packaging worklist for the ADD bucket from `inventory-match` results. This is the final step in the cyclonedx-universe-inventory pipeline, producing a prioritized list of packages ready for conda-forge recipe generation.

## Key Changes

### New Files

- **`.claude/skills/conda-forge-expert/scripts/add_handoff.py`** (379 lines)
  - Main implementation of the `add-handoff` CLI
  - Bounded, on-demand PyPI enrichment for ADD-bucket packages lacking `json_fetched_at`
  - Fail-closed license validation (NULL `license_spdx` → `license-unknown` blocker, never silent pass)
  - Readiness scoring via canonical Phase S formula, scoped to enriched slice
  - Markdown worklist report generation with blockers, signals_absent, and metadata
  - ADD-NONPYPI entries appended unscored with upstream purl identity
  - Freshness gate: refuses atlas older than 14 days (overridable with `--allow-stale`)

- **`.claude/scripts/conda-forge-expert/add_handoff.py`** (18 lines)
  - Public CLI entrypoint wrapper delegating to canonical skill script

- **`.claude/skills/conda-forge-expert/tests/unit/test_add_handoff.py`** (266 lines)
  - Comprehensive unit test suite covering:
    - Enrichment idempotency (zero-fetch on second run via Phase R's upsert discipline)
    - Fail-closed license rule (NULL and non-OSI licenses block; --no-enrich leaves rows blocked)
    - 404 vs. transient-failure semantics (404 bumps `json_fetched_at`, transient does not)
    - --limit reporting of dropped names (never silent truncation)
    - Readiness-desc ordering with unscored entries last
    - ADD-NONPYPI purl generation and sorting
    - In-flight PR and local recipe surfacing

### Modified Files

- **`.claude/skills/conda-forge-expert/scripts/conda_forge_atlas.py`**
  - Extracted PyPI JSON parsing and upsert logic into new `phase_r_upsert_one()` function
    - Shared write path for Phase R bulk enrichment and S6 bounded single-package enrichment
    - Ensures parse semantics never drift between callers
    - Returns outcome string ('fetched' | 'not_found' | 'failed') for caller logic
  - Refactored `phase_r_pypi_json_enrich()` to call `phase_r_upsert_one()` (no logic change)
  - Extracted readiness scoring into new `apply_readiness_scores(names=None)` function
    - `names=None` scores entire table (Phase S); name list scopes to slice (S6 re-score)
    - Canonical formula applied identically in both contexts
    - Commits and returns rowcount

- **`pixi.toml`**
  - Added `add-handoff` task invoking the public CLI entrypoint

- **`.claude/skills/conda-forge-expert/tests/meta/test_all_scripts_runnable.py`**
  - Added `add_handoff.py` to the runnable scripts list

## Design Decisions

1. **Fail-Closed License Rule (S6 spec)**: NULL `license_spdx` is treated as `license-unknown` blocker regardless of enrichment status. Under `--no-enrich`, un-enriched rows stay blocked (not clean). This prevents silent passes on missing data.

2. **Idempotent Enrichment**: Uses Phase R's own `phase_r_upsert_one()` write path. Already-enriched names (with `json_fetched_at` set) are skipped entirely on subsequent runs, proving idempotency.

3. **Canonical Scoring**: The Phase S readiness formula is extracted into `apply_readiness_

https://claude.ai/code/session_01WNh17BsQ7kSyAkJjJ5pUcj